### PR TITLE
Removing archive definitions we don't need

### DIFF
--- a/psconfig/esnet-psconfig.json
+++ b/psconfig/esnet-psconfig.json
@@ -12,6 +12,15 @@
       ],
       "display-name" : "ESnet"
    },
+   "archives" : {
+     "ps-east" : {
+         "archiver" : "esmond",
+         "data" : {
+            "measurement-agent" : "{% scheduled_by_address %}",
+            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
+         }
+     }
+   },
   "addresses" : {
    "albq-ps-lat.es.net" : {
       "_meta" : {
@@ -4344,2815 +4353,6 @@
          },
          "address" : "132.170.30.38",
          "host" : "132.170.30.38"
-      }
-   },
-   "archives" : {
-     "albq-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "ameshwh-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "anl221-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "anl541b-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "atla-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "bnl515-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "bnl515b-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "bois-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "bost-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "cern513-ps.es.net" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-      }
-  }, 
-  "cern773-ps.es.net" : {
-   "archiver" : "esmond",
-   "data" : {
-      "measurement-agent" : "{% scheduled_by_address %}",
-      "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-   }
-}, 
-     "chat-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "chic-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "denv-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "elpa-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "eqxam3-ps.es.net" : {
-       "archiver" : "esmond",
-       "data" : {
-          "measurement-agent" : "{% scheduled_by_address %}",
-          "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-       }
-     },
-     "eqxch2-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "eqxda3-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "eqxdc4-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "eqxld8-ps.es.net" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-      }
-  },
-     "eqxsv5-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "fnalfcc-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "fnalgcc-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "frib-a-ps.es.net" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-      }
-      },
-      "frib-b-ps.es.net" : {
-       "archiver" : "esmond",
-       "data" : {
-          "measurement-agent" : "{% scheduled_by_address %}",
-          "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-       }
-    },
-     "ga-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "germantown-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "hous-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "inleil-ps.es.net" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-      }
-  }, 
-  "inlerob-ps.es.net" : {
-   "archiver" : "esmond",
-   "data" : {
-      "measurement-agent" : "{% scheduled_by_address %}",
-      "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-   }
-}, 
-     "jlab12-ps.es.net" : {
-       "archiver" : "esmond",
-       "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     }, 
-     "jlab205-ps.es.net" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-      }
-     }, 
-     "kans-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "lasv-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "lbnl50-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "lbnl59-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "llnl-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "losa-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "nash-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "netlpgh-ps.es.net" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-      }
-  },     
-     "newy32aoa-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "newy1118th-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "orau-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "ornl1064-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "ornl5600-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "pppl-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "sacr-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-    "salt-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "sand-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "seat-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "snlca-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "slac50n-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "slac50s-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "star-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "sunn-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "wash-ps.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-         }
-     },
-     "172.64.36.1" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "http://172.64.36.1:8085/esmond/perfsonar/archive/"
-      }
- },
- "172.64.36.2" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "http://172.64.36.2:8085/esmond/perfsonar/archive/"
-      }
- },
-     "roc-ps-tp.tacc.utexas.edu" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-      }
-  },
-     "nrel-pt1.nrel.gov" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-      }
-     },
-     "nrel-perf01-100g.nrel.gov" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-      }
-     },
-     "grinch.phys.uconn.edu" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-      }
-     },
-     "sciphy-ps.jlab.org" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-      }
-     },
-     "jlab4.jlab.org" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-      }
-     },
-     "dmz-ps.jlab.org" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "https://ps-east.es.net/esmond/perfsonar/archive/"
-      }
-     },
-     "perfsonar01.frib.msu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-             "measurement-agent" : "{% scheduled_by_address %}",
-             "url" : "https://perfsonar01.frib.msu.edu/esmond/perfsonar/archive/"
-      }
-     },
-     "noc-ps-1-meas.scconf.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://noc-ps-1-meas.scconf.org:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "perfsonar-conf-conf-rtr-jnpr-1.22.scconf.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-conf-conf-rtr-jnpr-1.22.scconf.org:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "ps-10g-dnoc420.scconf.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-10g-dnoc420.scconf.org:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "ps-10g-dnoc1034.scconf.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-10g-dnoc1034.scconf.org:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "ps-10g-dnoc2316.scconf.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-10g-dnoc2316.scconf.org:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "ps-10g-dnoc2639.scconf.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-10g-dnoc2639.scconf.org:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "ps-10g-dnoc4026.scconf.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-10g-dnoc4026.scconf.org:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "perf-dal.tx-learn.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perf-dal.tx-learn.net:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "perfsonar.rc.asu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.rc.asu.edu:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "lbnl59-doenet-owamp.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://lbnl59-doenet-owamp.es.net:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "lbnl59-doenet-pt1-v6.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://lbnl59-doenet-pt1-v6.es.net:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "lbnl59-doenet-owamp-v6.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://lbnl59-doenet-owamp-v6.es.net:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "198.129.254.9" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://198.129.254.9:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "198.129.252.138" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://198.129.252.138:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "doenetemla-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://doenetemla-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-     },
-     "rc-dc-perfsonar.rc.sc.edu" : {
-          "archiver" : "esmond",
-          "data" : {
-             "measurement-agent" : "{% scheduled_by_address %}",
-             "url" : "http://rc-dc-perfsonar.rc.sc.edu:8085/esmond/perfsonar/archive/"
-          }
-     },
-     "holyperfsonar.rc.fas.harvard.edu" : {
-          "archiver" : "esmond",
-          "data" : {
-             "measurement-agent" : "{% scheduled_by_address %}",
-             "url" : "http://holyperfsonar.rc.fas.harvard.edu:8085/esmond/perfsonar/archive/"
-          }
-     },
-     "psmp-gn-bw-01-lon-uk.geant.net" : {
-          "archiver" : "esmond",
-          "data" : {
-             "measurement-agent" : "{% scheduled_by_address %}",
-             "url" : "http://psmp-gn-bw-01-lon-uk.geant.net:8085/esmond/perfsonar/archive/"
-          }
-     },
-     "psmp-gn-owd-01.lon.uk.geant.net" : {
-          "archiver" : "esmond",
-          "data" : {
-             "measurement-agent" : "{% scheduled_by_address %}",
-             "url" : "http://psmp-gn-owd-01.lon.uk.geant.net:8085/esmond/perfsonar/archive/"
-          }
-     },
-     "psmp-lhc-bw-fra-de.geant.org" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "http://psmp-lhc-bw-fra-de.geant.org:8085/esmond/perfsonar/archive/"
-      }
- },
- "psmp-lhc-owd-fra-de.geant.org" : {
-      "archiver" : "esmond",
-      "data" : {
-         "measurement-agent" : "{% scheduled_by_address %}",
-         "url" : "http://psmp-lhc-owd-fra-de.geant.org:8085/esmond/perfsonar/archive/"
-      }
- },
- "psmp-lhc-bw-gen-ch.geant.org" : {
-   "archiver" : "esmond",
-   "data" : {
-      "measurement-agent" : "{% scheduled_by_address %}",
-      "url" : "http://psmp-lhc-bw-gen-ch.geant.org:8085/esmond/perfsonar/archive/"
-   }
-},
-"psmp-lhc-owd-gen-ch.geant.org" : {
-   "archiver" : "esmond",
-   "data" : {
-      "measurement-agent" : "{% scheduled_by_address %}",
-      "url" : "http://psmp-lhc-owd-gen-ch.geant.org:8085/esmond/perfsonar/archive/"
-   }
-},
-"psmp-lhc-bw-lon-uk.geant.org" : {
-   "archiver" : "esmond",
-   "data" : {
-      "measurement-agent" : "{% scheduled_by_address %}",
-      "url" : "http://psmp-lhc-bw-lon-uk.geant.org:8085/esmond/perfsonar/archive/"
-   }
-},
-"psmp-lhc-owd-lon-uk.geant.org" : {
-   "archiver" : "esmond",
-   "data" : {
-      "measurement-agent" : "{% scheduled_by_address %}",
-      "url" : "http://psmp-lhc-owd-lon-uk.geant.org:8085/esmond/perfsonar/archive/"
-   }
-},
-"psmp-lhc-bw-par-fr.geant.org" : {
-   "archiver" : "esmond",
-   "data" : {
-      "measurement-agent" : "{% scheduled_by_address %}",
-      "url" : "http://psmp-lhc-bw-par-fr.geant.org:8085/esmond/perfsonar/archive/"
-   }
-},
-"psmp-lhc-owd-par-fr.geant.org" : {
-   "archiver" : "esmond",
-   "data" : {
-      "measurement-agent" : "{% scheduled_by_address %}",
-      "url" : "http://psmp-lhc-owd-par-fr.geant.org:8085/esmond/perfsonar/archive/"
-   }
-},
-     "perfsonar-ma-2.princeton.edu" : {
-          "archiver" : "esmond",
-          "data" : {
-             "measurement-agent" : "{% scheduled_by_address %}",
-             "url" : "http://perfsonar-ma-2.princeton.edu:8085/esmond/perfsonar/archive/"
-          }
-     },
-     "perfsonar-hpcrc.princeton.edu" : {
-          "archiver" : "esmond",
-          "data" : {
-             "measurement-agent" : "{% scheduled_by_address %}",
-             "url" : "http://perfsonar-hpcrc.princeton.edu:8085/esmond/perfsonar/archive/"
-          }
-     },
-     "doenetoro-pt1.es.net" : {
-           "archiver" : "esmond",
-           "data" : {
-              "measurement-agent" : "{% scheduled_by_address %}",
-              "url" : "http://doenetoro-pt1.es.net:8085/esmond/perfsonar/archive/"
-           }
-      },
-      "ps-dev-netlab-1.es.net" : {
-          "archiver" : "esmond",
-          "data" : {
-             "measurement-agent" : "{% scheduled_by_address %}",
-             "url" : "http://ps-dev-netlab-1.es.net/esmond/perfsonar/archive/"
-          }
-      },
-      "134.197.113.17" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://134.197.113.17/esmond/perfsonar/archive/"
-         }
-      },
-      "134.50.221.1" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://134.50.221.1/esmond/perfsonar/archive/"
-         }
-      },
-      "134.50.221.65" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://134.50.221.65/esmond/perfsonar/archive/"
-         }
-      },
-      "134.75.85.126" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://134.75.85.126/esmond/perfsonar/archive/"
-         }
-      },
-      "137.78.106.22" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://137.78.106.22/esmond/perfsonar/archive/"
-         }
-      },
-      "updc4.rtm.tns.its.psu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://updc4.rtm.tns.its.psu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "159.226.253.242" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://159.226.253.242/esmond/perfsonar/archive/"
-         }
-      },
-      "192.12.19.99" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://192.12.19.99/esmond/perfsonar/archive/"
-         }
-      },
-      "192.5.180.130" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://192.5.180.130/esmond/perfsonar/archive/"
-         }
-      },
-      "192.84.86.210" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://192.84.86.210/esmond/perfsonar/archive/"
-         }
-      },
-      "198.129.252.42" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://198.129.252.42:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "198.129.254.94" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://198.129.254.94:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "198.59.193.60" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://198.59.193.60/esmond/perfsonar/archive/"
-         }
-      },
-      "200.0.207.49" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://200.0.207.49/esmond/perfsonar/archive/"
-         }
-      },
-      "2001:252:0:304:" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://2001:252:0:304::2/esmond/perfsonar/archive/"
-         }
-      },
-      "2001:252:0:512:" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://2001:252:0:512::2/esmond/perfsonar/archive/"
-         }
-      },
-      "2001:400:1110:ff00:579:" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://2001:400:1110:ff00:579::9/esmond/perfsonar/archive/"
-         }
-      },
-      "204.99.128.11" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://204.99.128.11/esmond/perfsonar/archive/"
-         }
-      },
-      "207.231.241.157" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://207.231.241.157/esmond/perfsonar/archive/"
-         }
-      },
-      "207.231.241.25" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://207.231.241.25/esmond/perfsonar/archive/"
-         }
-      },
-      "210.25.189.178" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://210.25.189.178/esmond/perfsonar/archive/"
-         }
-      },
-      "210.25.189.78" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://210.25.189.78/esmond/perfsonar/archive/"
-         }
-      },
-      "2400:dd01:1010:101:f24d:a2ff:fe70:12a8" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://2400:dd01:1010:101:f24d:a2ff:fe70:12a8/esmond/perfsonar/archive/"
-         }
-      },
-      "2607:f460:a001:13:" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://2607:f460:a001:13::2/esmond/perfsonar/archive/"
-         }
-      },
-      "2607:f460:a001:9:" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://2607:f460:a001:9::2/esmond/perfsonar/archive/"
-         }
-      },
-      "55m-ps.sox.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://55m-ps.sox.net/esmond/perfsonar/archive/"
-         }
-      },
-      "56m-ps-4x10.sox.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://56m-ps-4x10.sox.net/esmond/perfsonar/archive/"
-         }
-      },
-      "64.71.82.222" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://64.71.82.222/esmond/perfsonar/archive/"
-         }
-      },
-      "65.254.110.185" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://65.254.110.185/esmond/perfsonar/archive/"
-         }
-      },
-      "65.254.110.193" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://65.254.110.193/esmond/perfsonar/archive/"
-         }
-      },
-      "PS-1G-v4-FFX-SDMZ.gmu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://PS-1G-v4-FFX-SDMZ.gmu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "act-actn-ps1.aarnet.net.au" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://act-actn-ps1.aarnet.net.au/esmond/perfsonar/archive/"
-         }
-      },
-      "ah-bonsai-perfsonar.bonsai.uoregon.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ah-bonsai-perfsonar.bonsai.uoregon.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "albq-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://albq-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "ameslab-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ameslab-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "ams-hbn-10g.perfsonar.ac.za" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ams-hbn-10g.perfsonar.ac.za/esmond/perfsonar/archive/"
-         }
-      },
-      "ams-hbn-1g.perfsonar.ac.za" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ams-hbn-1g.perfsonar.ac.za/esmond/perfsonar/archive/"
-         }
-      },
-      "amst-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://amst-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "anl-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://anl-pt1.es.net/esmond/perfsonar/archive/"
-         }
-      },
-      "anlborder-ps.it.anl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://anlborder-ps.it.anl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "bcdc-gw-40g-ps.gatech.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://bcdc-gw-40g-ps.gatech.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.llnl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.llnl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "bwctl-10g-ps.singaren.net.sg" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://bwctl-10g-ps.singaren.net.sg/esmond/perfsonar/archive/"
-         }
-      },
-      "cal-perfsonar-10g-v6.usc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://cal-perfsonar-10g-v6.usc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "cal-perfsonar-10g.usc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://cal-perfsonar-10g.usc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "cc-bonsai-perfsonar.bonsai.uoregon.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://cc-bonsai-perfsonar.bonsai.uoregon.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ccperfsonar1.in2p3.fr" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ccperfsonar1.in2p3.fr/esmond/perfsonar/archive/"
-         }
-      },
-      "ccperfsonar2.in2p3.fr" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ccperfsonar2.in2p3.fr/esmond/perfsonar/archive/"
-         }
-      },
-      "cl-perfsonar0-prod.cssd.pitt.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://cl-perfsonar0-prod.cssd.pitt.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "cpt-is-10g.perfsonar.ac.za" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://cpt-is-10g.perfsonar.ac.za/esmond/perfsonar/archive/"
-         }
-      },
-      "cpt-is-1g.perfsonar.ac.za" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://cpt-is-1g.perfsonar.ac.za/esmond/perfsonar/archive/"
-         }
-      },
-      "cpt-teraco-10g.perfsonar.ac.za" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://cpt-teraco-10g.perfsonar.ac.za/esmond/perfsonar/archive/"
-         }
-      },
-      "cs-perfsonar-2.cs.wisc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://cs-perfsonar-2.cs.wisc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "lbnl59-doenet-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://lbnl59-doenet-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "dps10.ucsc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://dps10.ucsc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "drperfsonar.fiu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://drperfsonar.fiu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "dspex2-dmz.idies.jhu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://dspex2-dmz.idies.jhu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "du-perfsonar-outside.du.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://du-perfsonar-outside.du.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ec-perfsonar.earlham.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ec-perfsonar.earlham.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "epgperf.ph.bham.ac.uk" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://epgperf.ph.bham.ac.uk/esmond/perfsonar/archive/"
-         }
-      },
-      "eqx-ash-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://eqx-ash-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "eqx-chi-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://eqx-chi-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "eqx-sj-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://eqx-sj-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "fiona-01.rdi2.rutgers.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://fiona-01.rdi2.rutgers.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "fiona-40g.ucsc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://fiona-40g.ucsc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "fiona-ps.net.berkeley.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://fiona-ps.net.berkeley.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "fiona-ps.ucsc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://fiona-ps.ucsc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "fiona.tools.ucla.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://fiona.tools.ucla.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ga-eastdtn-ps.gat.com" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ga-eastdtn-ps.gat.com/esmond/perfsonar/archive/"
-         }
-      },
-      "hcc-ps01.unl.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://hcc-ps01.unl.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "hcc-ps02.unl.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://hcc-ps02.unl.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "hive02.swarm.uhnet.net " : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://hive02.swarm.uhnet.net /esmond/perfsonar/archive/"
-         }
-      },
-      "hous-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://hous-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "hulkenberg.noc.unf.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://hulkenberg.noc.unf.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "isu-ps-001.indstate.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://isu-ps-001.indstate.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "its-perfmon.syr.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://its-perfmon.syr.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "jed-scdmz-perfsonar01.kaust.edu.sa" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://jed-scdmz-perfsonar01.kaust.edu.sa/esmond/perfsonar/archive/"
-         }
-      },
-      "jgi-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://jgi-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "jlab4.jlab.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://jlab4.jlab.org/esmond/perfsonar/archive/"
-         }
-      },
-      "kans-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://kans-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "lbnl59-ps-tp.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://lbnl59-ps-tp.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "lhc-bandwidth.twgrid.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://lhc-bandwidth.twgrid.org/esmond/perfsonar/archive/"
-         }
-      },
-      "lhcmon.bnl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://lhcmon.bnl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "lhcperfmon.bnl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://lhcperfmon.bnl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "lhcmon3.bnl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://lhcmon3.bnl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "m-cssc-b380-11.net.wisc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://m-cssc-b380-11.net.wisc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "m-cssc-b380-12.net.wisc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://m-cssc-b380-12.net.wisc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "mcc-perfsonar-10g-v6.usc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://mcc-perfsonar-10g-v6.usc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "mcc-perfsonar-10g.usc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://mcc-perfsonar-10g.usc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "mcc-perfsonar-1g-v6.usc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://mcc-perfsonar-1g-v6.usc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "mcc-perfsonar-1g.usc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://mcc-perfsonar-1g.usc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "mcln-ps.maxgigapop.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://mcln-ps.maxgigapop.net/esmond/perfsonar/archive/"
-         }
-      },
-      "mgalbre.jhh.jhu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://mgalbre.jhh.jhu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "monipe-sp-mpatraso.rnp.br" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://monipe-sp-mpatraso.rnp.br/esmond/perfsonar/archive/"
-         }
-      },
-      "monipe-sp-mpbanda.rnp.br" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://monipe-sp-mpbanda.rnp.br/esmond/perfsonar/archive/"
-         }
-      },
-      "monipe-sp-portal.rnp.br" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://monipe-sp-portal.rnp.br/esmond/perfsonar/archive/"
-         }
-      },
-      "mplex-ps.sox.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://mplex-ps.sox.net/esmond/perfsonar/archive/"
-         }
-      },
-      "mwt2-ps02.campuscluster.illinois.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://mwt2-ps02.campuscluster.illinois.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "nash-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://nash-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "nate.sdsc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://nate.sdsc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ndt.crc.nd.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ndt.crc.nd.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ndt.itcc.unc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ndt.itcc.unc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "nettest-outside.it.wsu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://nettest-outside.it.wsu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "nettest.boulder.noaa.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://nettest.boulder.noaa.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "nettest.it.wsu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://nettest.it.wsu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "netw-ps1.stanford.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://netw-ps1.stanford.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "newy-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://newy-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "nkn-inl-perfsonar.nkn.uidaho.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://nkn-inl-perfsonar.nkn.uidaho.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "nmon-msu.mich.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://nmon-msu.mich.net/esmond/perfsonar/archive/"
-         }
-      },
-      "nms1-10g.jp.apan.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://nms1-10g.jp.apan.net/esmond/perfsonar/archive/"
-         }
-      },
-      "nms4.jp.apan.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://nms4.jp.apan.net/esmond/perfsonar/archive/"
-         }
-      },
-      "nso-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://nso-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "nsw-brwy-ps1.aarnet.net.au" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://nsw-brwy-ps1.aarnet.net.au/esmond/perfsonar/archive/"
-         }
-      },
-      "ntg-perfsonar2.services.brown.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ntg-perfsonar2.services.brown.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ntg-perfsonar4.services.brown.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ntg-perfsonar4.services.brown.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "nysernet1-ps.net.cornell.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://nysernet1-ps.net.cornell.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "orau-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://orau-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "ornl-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ornl-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "owamp-scz.pnl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://owamp-scz.pnl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "pas-adhoc.chic.net.internet2.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://pas-adhoc.chic.net.internet2.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "pas-adhoc.newy32aoa.net.internet2.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://pas-adhoc.newy32aoa.net.internet2.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "pas-adhoc.seat.net.internet2.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://pas-adhoc.seat.net.internet2.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perf-scidmz-data.cac.washington.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perf-scidmz-data.cac.washington.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perf-unh.unh.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perf-unh.unh.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perf-v6.hfcas.ac.cn" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perf-v6.hfcas.ac.cn/esmond/perfsonar/archive/"
-         }
-      },
-      "perf-v6.ipp.ac.cn" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perf-v6.ipp.ac.cn/esmond/perfsonar/archive/"
-         }
-      },
-      "perf.hfcas.ac.cn" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perf.hfcas.ac.cn/esmond/perfsonar/archive/"
-         }
-      },
-      "perf.ipp.ac.cn" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perf.ipp.ac.cn/esmond/perfsonar/archive/"
-         }
-      },
-      "perf.stolaf.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perf.stolaf.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perf0.itrc.txstate.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perf0.itrc.txstate.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perf10g-tcom.colorado.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perf10g-tcom.colorado.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfSONAR.myren.net.my" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfSONAR.myren.net.my/esmond/perfsonar/archive/"
-         }
-      },
-      "perfbsu-temp.boisestate.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfbsu-temp.boisestate.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfs1-owamp.lanl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfs1-owamp.lanl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "perfs1.lanl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfs1.lanl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-10.cv.nrao.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-10.cv.nrao.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-1850.frgp.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-1850.frgp.net/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-bw.sprace.org.br" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-bw.sprace.org.br/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-bwctl.accre.vanderbilt.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-bwctl.accre.vanderbilt.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-core-fxb-10ge.umnet.umich.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-core-fxb-10ge.umnet.umich.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-corv-core-10g.net.oregonstate.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-corv-core-10g.net.oregonstate.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-dcw.ohsu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-dcw.ohsu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-de-kit.gridka.de" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-de-kit.gridka.de/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-dmz-10g.georgetown.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-dmz-10g.georgetown.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-dmz.marcc.jhu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-dmz.marcc.jhu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-hartford.cen.ct.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-hartford.cen.ct.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-lsu-frey-01.loni.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-lsu-frey-01.loni.org/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-lt.sprace.org.br" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-lt.sprace.org.br/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-net3.uoregon.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-net3.uoregon.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-ow.cnaf.infn.it" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-ow.cnaf.infn.it/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-owamp.accre.vanderbilt.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-owamp.accre.vanderbilt.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-ps.cnaf.infn.it" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-ps.cnaf.infn.it/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-sphrack-macc.umnet.umich.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-sphrack-macc.umnet.umich.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-storrs.cen.ct.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-storrs.cen.ct.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-test4.kek.jp" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-test4.kek.jp/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar-vm01.jc.rl.ac.uk" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar-vm01.jc.rl.ac.uk/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar7.dkrz.de" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar7.dkrz.de/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.fsl.byu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.fsl.byu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.gmca.aps.anl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.gmca.aps.anl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.hpc.wvu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.hpc.wvu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.ihep.ac.cn" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.ihep.ac.cn/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.its.msstate.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.its.msstate.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.ix.ui-iccn.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.ix.ui-iccn.org/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.malone.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.malone.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.marcc.jhu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.marcc.jhu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.marshall.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.marshall.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.merit.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.merit.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.nchc.org.tw" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.nchc.org.tw/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-lat.nersc.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-lat.nersc.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.net.cmu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.net.cmu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.ns.utk.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.ns.utk.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.ornl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.ornl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.oshean.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.oshean.org/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.pregi.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.pregi.net/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.sci.cwru.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.sci.cwru.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.si.umich.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.si.umich.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.tamucc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.tamucc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.ucad.sn" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.ucad.sn/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.unm.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.unm.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.uog.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.uog.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar.uoregon.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar.uoregon.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar01.cmsaf.mit.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar01.cmsaf.mit.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar01.ft.uam.es" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar01.ft.uam.es/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar01.ibest.uidaho.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar01.ibest.uidaho.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar01.its.uidaho.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar01.its.uidaho.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar01.jc.rl.ac.uk" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar01.jc.rl.ac.uk/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar02.cmsaf.mit.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar02.cmsaf.mit.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar02.ft.uam.es" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar02.ft.uam.es/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar1-rain.rc.pdx.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar1-rain.rc.pdx.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "128.219.141.59" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://128.219.141.59/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar1.rc.pdx.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar1.rc.pdx.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar1.research-lan.colostate.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar1.research-lan.colostate.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar1.sfasu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar1.sfasu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar2-de-kit.gridka.de" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar2-de-kit.gridka.de/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar2.icepp.jp" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar2.icepp.jp/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar2.ihep.ac.cn" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar2.ihep.ac.cn/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar2.rc.pdx.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar2.rc.pdx.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonar4.usd.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonar4.usd.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "perfsonarhsc.unt.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://perfsonarhsc.unt.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "personar-ve.nnmc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://personar-ve.nnmc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "pfsnr-pu.kenet.or.ke" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://pfsnr-pu.kenet.or.ke/esmond/perfsonar/archive/"
-         }
-      },
-      "pnwg-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://pnwg-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "pppl-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://pppl-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-10g-border-asm-0.tools.ucla.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-10g-border-asm-0.tools.ucla.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-10g-dmz.msu.montana.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-10g-dmz.msu.montana.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-10g.ncsa.illinois.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-10g.ncsa.illinois.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-2.oit.umass.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-2.oit.umass.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-40g-hpr01.stanford.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-40g-hpr01.stanford.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-arc-meter.nren.nasa.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-arc-meter.nren.nasa.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-bandwidth.atlas.unimelb.edu.au" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-bandwidth.atlas.unimelb.edu.au/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-bandwidth.hep.pnnl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-bandwidth.hep.pnnl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-bandwidth.hepnetcanada.ca" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-bandwidth.hepnetcanada.ca/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-border1-bwctl.lbl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-border1-bwctl.lbl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-border1-owamp.lbl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-border1-owamp.lbl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-bw.ln.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-bw.ln.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-bw.sdmz.rnp.br" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-bw.sdmz.rnp.br/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-datacenter.netserv.wayne.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-datacenter.netserv.wayne.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-delay.pnw-gigapop.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-delay.pnw-gigapop.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-dmz-1.unm.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-dmz-1.unm.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-grand-bw.kanren.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-grand-bw.kanren.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-grand-lt.kanren.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-grand-lt.kanren.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-ksu-bw.kanren.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-ksu-bw.kanren.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-ksu-lt.kanren.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-ksu-lt.kanren.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-latency.atlas.unimelb.edu.au" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-latency.atlas.unimelb.edu.au/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-latency.hepnetcanada.ca" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-latency.hepnetcanada.ca/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-lax-10g.cenic.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-lax-10g.cenic.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-lax-dc-owamp.cenic.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-lax-dc-owamp.cenic.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-lt.ampath.ampath.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-lt.ampath.ampath.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-lt.sdmz.rnp.br" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-lt.sdmz.rnp.br/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-sd.rc.uab.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-sd.rc.uab.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-svl-10g.cenic.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-svl-10g.cenic.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-svl-owamp.cenic.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-svl-owamp.cenic.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps-uva.dynes.virginia.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps-uva.dynes.virginia.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ps.3rox.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps.3rox.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps.daej.kreonet2.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps.daej.kreonet2.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps.daejeon.nfri.re.kr" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps.daejeon.nfri.re.kr/esmond/perfsonar/archive/"
-         }
-      },
-      "ps.iu.xsede.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps.iu.xsede.org/esmond/perfsonar/archive/"
-         }
-      },
-      "ps.ncar.xsede.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps.ncar.xsede.org/esmond/perfsonar/archive/"
-         }
-      },
-      "ps.ncp.edu.pk" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps.ncp.edu.pk/esmond/perfsonar/archive/"
-         }
-      },
-      "ps.ncsa.xsede.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps.ncsa.xsede.org/esmond/perfsonar/archive/"
-         }
-      },
-      "ps.nics.utk.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps.nics.utk.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ps.psc.xsede.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps.psc.xsede.org/esmond/perfsonar/archive/"
-         }
-      },
-      "ps.sdsc.xsede.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps.sdsc.xsede.org/esmond/perfsonar/archive/"
-         }
-      },
-      "ps.tacc.xsede.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps.tacc.xsede.org/esmond/perfsonar/archive/"
-         }
-      },
-      "ps.test.manlan.internet2.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps.test.manlan.internet2.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ps.test.wix.internet2.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps.test.wix.internet2.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ps1-100g-sdmz.chat.tmc.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps1-100g-sdmz.chat.tmc.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "ps1-akard-dlls.tx-learn.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps1-akard-dlls.tx-learn.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps1-hardy-hstn.tx-learn.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps1-hardy-hstn.tx-learn.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps1.daej.kreonet2.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps1.daej.kreonet2.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps1.netherlight.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps1.netherlight.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps1.renci.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps1.renci.org/esmond/perfsonar/archive/"
-         }
-      },
-      "ps2.netherlight.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps2.netherlight.net/esmond/perfsonar/archive/"
-         }
-      },
-      "ps3.crc.rice.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://ps3.crc.rice.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "psb-bw.ncsa.illinois.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psb-bw.ncsa.illinois.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "psl-bw.ncsa.illinois.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psl-bw.ncsa.illinois.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "psmp-gn-bw-01-ams-nl.geant.net:" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psmp-gn-bw-01-ams-nl.geant.net:/esmond/perfsonar/archive/"
-         }
-      },
-      "psmp-gn-bw-01-fra-de.geant.net:" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psmp-gn-bw-01-fra-de.geant.net:/esmond/perfsonar/archive/"
-         }
-      },
-      "psmp-gn-bw-01-gen.ch.geant.net:" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psmp-gn-bw-01-gen.ch.geant.net:/esmond/perfsonar/archive/"
-         }
-      },
-      "psmp-gn-bw-01-par-fr.geant.net:" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psmp-gn-bw-01-par-fr.geant.net:/esmond/perfsonar/archive/"
-         }
-      },
-      "psmp-gn-owd-01.ams-nl.geant.net:" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psmp-gn-owd-01.ams-nl.geant.net:/esmond/perfsonar/archive/"
-         }
-      },
-      "psmp-gn-owd-01.fra-de.geant.net:" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psmp-gn-owd-01.fra-de.geant.net:/esmond/perfsonar/archive/"
-         }
-      },
-      "psmp-gn-owd-01.gen.ch.geant.net:" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psmp-gn-owd-01.gen.ch.geant.net:/esmond/perfsonar/archive/"
-         }
-      },
-      "psmp-gn-owd-01.par-fr.geant.net:" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psmp-gn-owd-01.par-fr.geant.net:/esmond/perfsonar/archive/"
-         }
-      },
-      "psmsu01.aglt2.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psmsu01.aglt2.org/esmond/perfsonar/archive/"
-         }
-      },
-      "psmsu02.aglt2.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psmsu02.aglt2.org/esmond/perfsonar/archive/"
-         }
-      },
-      "psnr-farm10.slac.stanford.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psnr-farm10.slac.stanford.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "psonar-core.gw.utexas.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psonar-core.gw.utexas.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "psonar.arc.vt.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psonar.arc.vt.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "psonar5.deemz.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psonar5.deemz.net/esmond/perfsonar/archive/"
-         }
-      },
-      "psum01.aglt2.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psum01.aglt2.org/esmond/perfsonar/archive/"
-         }
-      },
-      "psum02.aglt2.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psum02.aglt2.org/esmond/perfsonar/archive/"
-         }
-      },
-      "psvm.nrel.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://psvm.nrel.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "rneonly-ps.ps.uhnet.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://rneonly-ps.ps.uhnet.net/esmond/perfsonar/archive/"
-         }
-      },
-      "sampaps01.if.usp.br" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://sampaps01.if.usp.br/esmond/perfsonar/archive/"
-         }
-      },
-      "sampaps02.if.usp.br" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://sampaps02.if.usp.br/esmond/perfsonar/archive/"
-         }
-      },
-      "scidmz-ps1.scidmz.uchicago.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://scidmz-ps1.scidmz.uchicago.net/esmond/perfsonar/archive/"
-         }
-      },
-      "scidmz-ps12.scidmz.uchicago.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://scidmz-ps12.scidmz.uchicago.net/esmond/perfsonar/archive/"
-         }
-      },
-      "scidmz-tp.ps.uhnet.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://scidmz-tp.ps.uhnet.net/esmond/perfsonar/archive/"
-         }
-      },
-      "sdm01.rcc.uchicago.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://sdm01.rcc.uchicago.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "snll-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://snll-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "sonar-west.net.yale.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://sonar-west.net.yale.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "spacesonar.mit.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://spacesonar.mit.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "speedtest1.net.siue.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://speedtest1.net.siue.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "speedtest2.pnl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://speedtest2.pnl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "speedy.greatplains.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://speedy.greatplains.net/esmond/perfsonar/archive/"
-         }
-      },
-      "srcf-ps.stanford.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://srcf-ps.stanford.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "sunn-pt1.es.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://sunn-pt1.es.net:8085/esmond/perfsonar/archive/"
-         }
-      },
-      "test10g.lsi.umich.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://test10g.lsi.umich.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "tonic.crest.iu.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://tonic.crest.iu.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "tsunami.pub.alcf.anl.gov" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://tsunami.pub.alcf.anl.gov/esmond/perfsonar/archive/"
-         }
-      },
-      "tul-ps.onenet.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://tul-ps.onenet.net/esmond/perfsonar/archive/"
-         }
-      },
-      "uct2-net1.mwt2.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://uct2-net1.mwt2.org/esmond/perfsonar/archive/"
-         }
-      },
-      "uct2-net2.mwt2.org" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://uct2-net2.mwt2.org/esmond/perfsonar/archive/"
-         }
-      },
-      "uhmanoa-dl.ps.uhnet.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://uhmanoa-dl.ps.uhnet.net/esmond/perfsonar/archive/"
-         }
-      },
-      "uhmanoa-tp.ps.uhnet.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://uhmanoa-tp.ps.uhnet.net/esmond/perfsonar/archive/"
-         }
-      },
-      "uofu-ddc-dmz-bandwidth.chpc.utah.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://uofu-ddc-dmz-bandwidth.chpc.utah.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "uofu-ddc-dmz-latency.chpc.utah.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://uofu-ddc-dmz-latency.chpc.utah.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "uofu-science-dmz-bandwidth.chpc.utah.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://uofu-science-dmz-bandwidth.chpc.utah.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "uofu-science-dmz-latency.chpc.utah.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://uofu-science-dmz-latency.chpc.utah.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "vu-perf2.it.vanderbilt.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://vu-perf2.it.vanderbilt.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "web100.pnw-gigapop.net" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://web100.pnw-gigapop.net/esmond/perfsonar/archive/"
-         }
-      },
-      "wuit-s-00045.wustl.edu" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://wuit-s-00045.wustl.edu/esmond/perfsonar/archive/"
-         }
-      },
-      "132.170.30.38" : {
-         "archiver" : "esmond",
-         "data" : {
-            "measurement-agent" : "{% scheduled_by_address %}",
-            "url" : "http://132.170.30.38/esmond/perfsonar/archive/"
-         }
       }
    },
    "groups" : {
@@ -13997,532 +11197,355 @@
         "_meta" : {
            "display-name" : "albq-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "albq-ps.es.net"
-        ]
+        }
      },
      "ameshwh-ps.es.net" : {
         "_meta" : {
            "display-name" : "ameshwh-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "ameshwh-ps.es.net"
-        ]
+        }
      },
      "anl221-ps.es.net" : {
         "_meta" : {
            "display-name" : "anl221-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "anl221-ps.es.net"
-        ]
+        }
      },
      "anl541b-ps.es.net" : {
         "_meta" : {
            "display-name" : "anl541b-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "anl541b-ps.es.net"
-        ]
+        }
      },
      "atla-ps.es.net" : {
         "_meta" : {
            "display-name" : "atla-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "atla-ps.es.net"
-        ]
+        }
      },
      "bnl515-ps.es.net" : {
         "_meta" : {
            "display-name" : "bnl515-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "bnl515-ps.es.net"
-        ]
+        }
      },
      "bnl515b-ps.es.net" : {
         "_meta" : {
            "display-name" : "bnl515b-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "bnl515b-ps.es.net"
-        ]
+        }
      },
      "bois-ps.es.net" : {
         "_meta" : {
            "display-name" : "bois-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "bois-ps.es.net"
-        ]
+        }
      },
      "bost-ps.es.net" : {
         "_meta" : {
            "display-name" : "bost-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "bost-ps.es.net"
-        ]
+        }
      },
      "cern513-ps.es.net" : {
       "_meta" : {
          "display-name" : "cern513-ps.es.net",
          "organization-display-name" : "ESnet"
-      },
-      "archives" : [
-         "cern513-ps.es.net"
-      ]
+      }
    },
    "cern773-ps.es.net" : {
       "_meta" : {
          "display-name" : "cern773-ps.es.net",
          "organization-display-name" : "ESnet"
-      },
-      "archives" : [
-         "cern773-ps.es.net"
-      ]
+      }
    },
      "chat-ps.es.net" : {
         "_meta" : {
            "display-name" : "chat-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "chat-ps.es.net"
-        ]
+        }
      },
      "chic-ps.es.net" : {
         "_meta" : {
            "display-name" : "chic-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "chic-ps.es.net"
-        ]
+        }
      },
      "denv-ps.es.net" : {
         "_meta" : {
            "display-name" : "denv-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "denv-ps.es.net"
-        ]
+        }
      },
      "elpa-ps.es.net" : {
         "_meta" : {
            "display-name" : "elpa-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "elpa-ps.es.net"
-        ]
+        }
      },
      "eqxam3-ps.es.net" : {
        "_meta" : {
            "display-name" : "eqxam3-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-       "archives" : [
-          "eqxam3-ps.es.net"
-       ]
+        }
      },
      "eqxch2-ps.es.net" : {
         "_meta" : {
            "display-name" : "eqxsv5-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "eqxsv5-ps.es.net"
-        ]
+        }
      },
      "eqxda3-ps.es.net" : {
         "_meta" : {
            "display-name" : "eqxda3-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "eqxda3-ps.es.net"
-        ]
+        }
      },
      "eqxdc4-ps.es.net" : {
         "_meta" : {
            "display-name" : "eqxdc4-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "eqxdc4-ps.es.net"
-        ]
+        }
      },
      "eqxld8-ps.es.net" : {
       "_meta" : {
          "display-name" : "eqxld8-ps.es.net",
          "organization-display-name" : "ESnet"
-      },
-      "archives" : [
-         "eqxld8-ps.es.net"
-      ]
+      }
    },
      "eqxsv5-ps.es.net" : {
         "_meta" : {
            "display-name" : "eqxsv5-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "eqxsv5-ps.es.net"
-        ]
+        }
      },
      "fnalfcc-ps.es.net" : {
         "_meta" : {
            "display-name" : "fnalfcc-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "fnalfcc-ps.es.net"
-        ]
+        }
      },
      "fnalgcc-ps.es.net" : {
         "_meta" : {
            "display-name" : "fnalgcc-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "fnalgcc-ps.es.net"
-        ]
+        }
      },
      "frib-a-ps.es.net" : {
       "_meta" : {
          "display-name" : "frib-a-ps.es.net",
          "organization-display-name" : "ESnet"
-      },
-      "archives" : [
-         "frib-a-ps.es.net"
-      ]
+      }
    },
    "frib-b-ps.es.net" : {
       "_meta" : {
          "display-name" : "frib-b-ps.es.net",
          "organization-display-name" : "ESnet"
-      },
-      "archives" : [
-         "frib-b-ps.es.net"
-      ]
+      }
    },
      "ga-ps.es.net" : {
         "_meta" : {
            "display-name" : "ga-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "ga-ps.es.net"
-        ]
+        }
      },
      "germantown-ps.es.net" : {
         "_meta" : {
            "display-name" : "germantown-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "germantown-ps.es.net"
-        ]
+        }
      },
      "hous-ps.es.net" : {
         "_meta" : {
            "display-name" : "hous-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "hous-ps.es.net"
-        ]
+        }
      },
      "inleil-ps.es.net" : {
       "_meta" : {
          "display-name" : "inleil-ps.es.net",
          "organization-display-name" : "ESnet"
-      },
-      "archives" : [
-         "inleil-ps.es.net"
-      ]
+      }
    },
    "inlerob-ps.es.net" : {
       "_meta" : {
          "display-name" : "inlerob-ps.es.net",
          "organization-display-name" : "ESnet"
-      },
-      "archives" : [
-         "inlerob-ps.es.net"
-      ]
+      }
    },
    "jlab12-ps.es.net" : {
       "_meta" : {
          "display-name" : "jlab12-ps.es.net",
          "organization-display-name" : "ESnet"
-      },
-      "archives" : [
-         "jlab12-ps.es.net"
-      ]
+      }
    },
    "jlab205-ps.es.net" : {
       "_meta" : {
          "display-name" : "jlab205-ps.es.net",
          "organization-display-name" : "ESnet"
-      },
-      "archives" : [
-         "jlab205-ps.es.net"
-      ]
+      }
    },
      "kans-ps.es.net" : {
         "_meta" : {
            "display-name" : "kans-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "kans-ps.es.net"
-        ]
+        }
      },
      "lasv-ps.es.net" : {
         "_meta" : {
            "display-name" : "lasv-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "lasv-ps.es.net"
-        ]
+        }
      },
      "lbnl50-ps.es.net" : {
         "_meta" : {
            "display-name" : "lbnl50-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "lbnl50-ps.es.net"
-        ]
+        }
      },
      "lbnl59-ps.es.net" : {
         "_meta" : {
            "display-name" : "lbnl59-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "lbnl59-ps.es.net"
-        ]
+        }
      },
      "llnl-ps.es.net" : {
         "_meta" : {
            "display-name" : "llnl-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "llnl-ps.es.net"
-        ]
+        }
      },
      "losa-ps.es.net" : {
         "_meta" : {
            "display-name" : "losa-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "losa-ps.es.net"
-        ]
+        }
      },
      "nash-ps.es.net" : {
         "_meta" : {
            "display-name" : "nash-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "nash-ps.es.net"
-        ]
+        }
      },
      "netlpgh-ps.es.net" : {
       "_meta" : {
          "display-name" : "netlpgh-ps.es.net",
          "organization-display-name" : "ESnet"
-      },
-      "archives" : [
-         "netlpgh-ps.es.net"
-      ]
+      }
    },
      "newy1118th-ps.es.net" : {
         "_meta" : {
            "display-name" : "newy1118th-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "newy1118th-ps.es.net"
-        ]
+        }
      },
      "newy32aoa-ps.es.net" : {
         "_meta" : {
            "display-name" : "newy32aoa-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "newy32aoa-ps.es.net"
-        ]
+        }
      },
      "orau-ps.es.net" : {
         "_meta" : {
            "display-name" : "orau-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "orau-ps.es.net"
-        ]
+        }
      },
      "ornl1064-ps.es.net" : {
         "_meta" : {
            "display-name" : "ornl1064-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "ornl1064-ps.es.net"
-        ]
+        }
      },
      "ornl5600-ps.es.net" : {
         "_meta" : {
            "display-name" : "ornl5600-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "ornl5600-ps.es.net"
-        ]
+        }
      },
      "pppl-ps.es.net" : {
       "_meta" : {
          "display-name" : "pppl-ps.es.net",
          "organization-display-name" : "ESnet"
-      },
-      "archives" : [
-         "pppl-ps.es.net"
-      ]
+      }
    },
      "sacr-ps.es.net" : {
         "_meta" : {
            "display-name" : "sacr-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "sacr-ps.es.net"
-        ]
+        }
      },
     "salt-ps.es.net" : {
         "_meta" : {
            "display-name" : "salt-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "salt-ps.es.net"
-        ]
+        }
      },
      "sand-ps.es.net" : {
         "_meta" : {
            "display-name" : "sand-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "sand-ps.es.net"
-        ]
+        }
      },
      "seat-ps.es.net" : {
         "_meta" : {
            "display-name" : "seat-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "seat-ps.es.net"
-        ]
+        }
      },
      "slac50n-ps.es.net" : {
         "_meta" : {
            "display-name" : "slac50n-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "slac50n-ps.es.net"
-        ]
+        }
      },
      "slac50s-ps.es.net" : {
         "_meta" : {
            "display-name" : "slac50s-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "slac50s-ps.es.net"
-        ]
+        }
      },
      "snlca-ps.es.net" : {
         "_meta" : {
            "display-name" : "snlca-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "snlca-ps.es.net"
-        ]
+        }
      },
      "star-ps.es.net" : {
         "_meta" : {
            "display-name" : "star-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "star-ps.es.net"
-        ]
+        }
      },
      "sunn-ps.es.net" : {
         "_meta" : {
            "display-name" : "sunn-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "sunn-ps.es.net"
-        ]
+        }
      },
      "wash-ps.es.net" : {
         "_meta" : {
            "display-name" : "wash-ps.es.net",
            "organization-display-name" : "ESnet"
-        },
-        "archives" : [
-           "wash-ps.es.net"
-        ]
+        }
      },
      "172.64.36.1" : {
       "_meta" : {
          "display-name" : "172.64.36.1",
          "organization-display-name" : "Cloudflare DNS"
-      },
-      "archives" : [
-         "172.64.36.1"
-      ]
+      }
   },
   "172.64.36.2" : {
       "_meta" : {
          "display-name" : "172.64.36.2",
          "organization-display-name" : "Cloudflare DNS"
-      },
-      "archives" : [
-         "172.64.36.2"
-      ]
+      }
   },
      "roc-ps-tp.tacc.utexas.edu" : {
       "_meta" : {
          "display-name" : "roc-ps-tp.tacc.utexas.edu",
          "organization-display-name" : "TACC"
       },
-      "archives" : [
-         "roc-ps-tp.tacc.utexas.edu"  
-      ],
       "no-agent" : true
    },
      "perfsonar01.frib.msu.edu" : {
@@ -14530,136 +11553,91 @@
            "display-name" : "perfsonar01.frib.msu.edu",
            "organization-display-name" : "FRIB"
          },
-         "archives" : [
-            "perfsonar01.frib.msu.edu"
-      ],
       "no-agent" : true
    },
      "noc-ps-1-meas.scconf.org" : {
         "_meta" : {
            "display-name" : "noc-ps-1-meas.scconf.org",
            "organization-display-name" : "SCinet"
-        },
-        "archives" : [
-           "noc-ps-1-meas.scconf.org"
-        ]
+        }
      },
      "perfsonar-conf-conf-rtr-jnpr-1.22.scconf.org" : {
         "_meta" : {
            "display-name" : "perfsonar-conf-conf-rtr-jnpr-1.22.scconf.org",
            "organization-display-name" : "SCinet"
-        },
-        "archives" : [
-           "perfsonar-conf-conf-rtr-jnpr-1.22.scconf.org"
-        ]
+        }
      },
      "ps-10g-dnoc420.scconf.org" : {
         "_meta" : {
            "display-name" : "ps-10g-dnoc420.scconf.org",
            "organization-display-name" : "SCinet"
-        },
-        "archives" : [
-           "ps-10g-dnoc420.scconf.org"
-        ]
+        }
      },
      "ps-10g-dnoc1034.scconf.org" : {
         "_meta" : {
            "display-name" : "ps-10g-dnoc1034.scconf.org",
            "organization-display-name" : "SCinet"
-        },
-        "archives" : [
-           "ps-10g-dnoc1034.scconf.org"
-        ]
+        }
      },
      "ps-10g-dnoc2316.scconf.org" : {
         "_meta" : {
            "display-name" : "ps-10g-dnoc2316.scconf.org",
            "organization-display-name" : "SCinet"
-        },
-        "archives" : [
-           "ps-10g-dnoc2316.scconf.org"
-        ]
+        }
      },
      "ps-10g-dnoc2639.scconf.org" : {
         "_meta" : {
            "display-name" : "ps-10g-dnoc2639.scconf.org",
            "organization-display-name" : "SCinet"
-        },
-        "archives" : [
-           "ps-10g-dnoc2639.scconf.org"
-        ]
+        }
      },
      "ps-10g-dnoc4026.scconf.org" : {
         "_meta" : {
            "display-name" : "ps-10g-dnoc4026.scconf.org",
            "organization-display-name" : "SCinet"
-        },
-        "archives" : [
-           "ps-10g-dnoc4026.scconf.org"
-        ]
+        }
      },
      "perf-dal.tx-learn.net" : {
         "_meta" : {
            "display-name" : "perf-dal.tx-learn.net",
            "organization-display-name" : "LEARN"
-        },
-        "archives" : [
-           "perf-dal.tx-learn.net"
-        ]
+        }
      },
      "perfsonar.rc.asu.edu" : {
         "_meta" : {
            "display-name" : "perfsonar.rc.asu.edu",
            "organization-display-name" : "Arizona State"
-        },
-        "archives" : [
-           "perfsonar.rc.asu.edu"
-        ]
+        }
      },
      "doenetoro-pt1.es.net" : {
         "_meta" : {
            "display-name" : "doenetoro-pt1.es.net",
            "organization-display-name" : "Lumens"
-        },
-        "archives" : [
-           "doenetoro-pt1.es.net"
-        ]
+        }
      },
      "doenetemla-pt1.es.net" : {
          "_meta" : {
             "display-name" : "doenetemla-pt1.es.net",
             "organization-display-name" : "Lumens"
-         },
-         "archives" : [
-            "doenetemla-pt1.es.net"
-         ]
+         }
      },
      "rc-dc-perfsonar.rc.sc.edu" : {
          "_meta" : {
             "display-name" : "rc-dc-perfsonar.rc.sc.edu",
             "organization-display-name" : "UofSC"
-         },
-         "archives" : [
-            "rc-dc-perfsonar.rc.sc.edu"
-         ]
+         }
      },
      "holyperfsonar.rc.fas.harvard.edu" : {
          "_meta" : {
             "display-name" : "holyperfsonar.rc.fas.harvard.edu",
             "organization-display-name" : "Harvard"
-         },
-         "archives" : [
-            "holyperfsonar.rc.fas.harvard.edu"
-         ]
+         }
      },
      "psmp-gn-owd-01.lon.uk.geant.net" : {
          "_meta" : {
             "display-name" : "psmp-gn-owd-01.lon.uk.geant.net",
             "organization-display-name" : "GEANT"
          },
-         "archives" : [
-            "psmp-gn-owd-01.lon.uk.geant.net"
-         ],
          "no-agent" : true
      },
      "psmp-gn-bw-01-lon-uk.geant.net" : {
@@ -14667,9 +11645,6 @@
             "display-name" : "psmp-gn-bw-01-lon-uk.geant.net",
             "organization-display-name" : "GEANT"
          },
-         "archives" : [
-            "psmp-gn-bw-01-lon-uk.geant.net"
-         ],
          "no-agent" : true
      },
      "psmp-lhc-owd-fra-de.geant.org" : {
@@ -14677,9 +11652,6 @@
          "display-name" : "psmp-lhc-owd-fra-de.geant.org",
          "organization-display-name" : "GEANT"
       },
-      "archives" : [
-         "psmp-lhc-owd-fra-de.geant.org"
-      ],
       "no-agent" : true
   },
   "psmp-lhc-bw-fra-de.geant.org" : {
@@ -14687,9 +11659,6 @@
          "display-name" : "psmp-lhc-bw-fra-de.geant.org",
          "organization-display-name" : "GEANT"
       },
-      "archives" : [
-         "psmp-lhc-bw-fra-de.geant.org"
-      ],
       "no-agent" : true
   },
   "psmp-lhc-owd-gen-ch.geant.org" : {
@@ -14697,9 +11666,6 @@
       "display-name" : "psmp-lhc-owd-gen-ch.geant.org",
       "organization-display-name" : "GEANT"
    },
-   "archives" : [
-      "psmp-lhc-owd-gen-ch.geant.org"
-   ],
    "no-agent" : true
 },
 "psmp-lhc-bw-gen-ch.geant.org" : {
@@ -14707,9 +11673,6 @@
       "display-name" : "psmp-lhc-bw-gen-ch.geant.org",
       "organization-display-name" : "GEANT"
    },
-   "archives" : [
-      "psmp-lhc-bw-gen-ch.geant.org"
-   ],
    "no-agent" : true
 },  
 "psmp-lhc-owd-lon-uk.geant.org" : {
@@ -14717,9 +11680,6 @@
       "display-name" : "psmp-lhc-owd-lon-uk.geant.org",
       "organization-display-name" : "GEANT"
    },
-   "archives" : [
-      "psmp-lhc-owd-lon-uk.geant.org"
-   ],
    "no-agent" : true
 },
 "psmp-lhc-bw-lon-uk.geant.org" : {
@@ -14727,9 +11687,6 @@
       "display-name" : "psmp-lhc-bw-lon-uk.geant.org",
       "organization-display-name" : "GEANT"
    },
-   "archives" : [
-      "psmp-lhc-bw-lon-uk.geant.org"
-   ],
    "no-agent" : true
 },
 "psmp-lhc-bw-par-fr.geant.org" : {
@@ -14737,9 +11694,6 @@
       "display-name" : "psmp-lhc-bw-par-fr.geant.org",
       "organization-display-name" : "GEANT"
    },
-   "archives" : [
-      "psmp-lhc-bw-par-fr.geant.org"
-   ],
    "no-agent" : true
 },
 "psmp-lhc-owd-par-fr.geant.org" : {
@@ -14747,9 +11701,6 @@
       "display-name" : "psmp-lhc-owd-par-fr.geant.org",
       "organization-display-name" : "GEANT"
    },
-   "archives" : [
-      "psmp-lhc-owd-par-fr.geant.org"
-   ],
    "no-agent" : true
 },
      "nrel-pt1.nrel.gov" : {
@@ -14757,9 +11708,6 @@
             "display-name" : "nrel-pt1.nrel.gov",
             "organization-display-name" : "NREL"
          },
-         "archives" : [
-            "nrel-pt1.nrel.gov"
-         ],
          "no-agent" : true
      },
      "nrel-perf01-100g.nrel.gov" : {
@@ -14767,9 +11715,6 @@
             "display-name" : "nrel-perf01-100g.nrel.gov",
             "organization-display-name" : "NREL"
          },
-         "archives" : [
-            "nrel-perf01-100g.nrel.gov"
-         ],
          "no-agent" : true
      },
      "grinch.phys.uconn.edu" : {
@@ -14777,9 +11722,6 @@
             "display-name" : "grinch.phys.uconn.edu",
             "organization-display-name" : "UCONN"
          },
-         "archives" : [
-            "grinch.phys.uconn.edu"
-         ],
          "no-agent" : true
      },
      "sciphy-ps.jlab.org" : {
@@ -14787,9 +11729,6 @@
             "display-name" : "sciphy-ps.jlab.org",
             "organization-display-name" : "JLAB"
          },
-         "archives" : [
-            "sciphy-ps.jlab.org"
-         ],
          "no-agent" : true
      },
      "dmz-ps.jlab.org" : {
@@ -14797,9 +11736,6 @@
             "display-name" : "dmz-ps.jlab.org",
             "organization-display-name" : "JLAB"
          },
-         "archives" : [
-            "dmz-ps.jlab.org"
-         ],
          "no-agent" : true
      },
      "ps2-61.nrel.gov" : {
@@ -14818,73 +11754,49 @@
          "_meta" : {
             "display-name" : "perfsonar-ma-2.princeton.edu",
             "organization-display-name" : "Princeton"
-         },
-         "archives" : [
-            "perfsonar-ma-2.princeton.edu"
-         ]
+         }
      },
      "perfsonar-hpcrc.princeton.edu" : {
          "_meta" : {
             "display-name" : "perfsonar-hpcrc.princeton.edu",
             "organization-display-name" : "Princeton"
-         },
-         "archives" : [
-            "perfsonar-hpcrc.princeton.edu"
-         ]
+         }
      },
       "lbnl59-doenet-pt1.es.net" : {
            "_meta" : {
               "display-name" : "lbnl59-doenet-pt1.es.net",
               "organization-display-name" : "ESnet"
-           },
-           "archives" : [
-              "lbnl59-doenet-pt1.es.net"
-           ]
+           }
        },
        "lbnl59-doenet-pt1-v6.es.net" : {
             "_meta" : {
                "display-name" : "lbnl59-doenet-pt1-v6.es.net",
                "organization-display-name" : "ESnet"
-            },
-            "archives" : [
-               "lbnl59-doenet-pt1-v6.es.net"
-            ]
+            }
         },
         "198.129.254.9" : {
              "_meta" : {
                 "display-name" : "198.129.254.9",
                 "organization-display-name" : "ESnet"
-             },
-             "archives" : [
-                "198.129.254.9"
-             ]
+             }
          },
          "lbnl59-doenet-owamp.es.net" : {
               "_meta" : {
                  "display-name" : "lbnl59-doenet-owamp.es.net",
                  "organization-display-name" : "ESnet"
-              },
-              "archives" : [
-                 "lbnl59-doenet-owamp.es.net"
-              ]
+              }
           },
           "lbnl59-doenet-owamp-v6.es.net" : {
                "_meta" : {
                   "display-name" : "lbnl59-doenet-owamp-v6.es.net",
                   "organization-display-name" : "ESnet"
-               },
-               "archives" : [
-                  "lbnl59-doenet-owamp-v6.es.net"
-               ]
+               }
            },
            "198.129.252.138" : {
                 "_meta" : {
                    "display-name" : "198.129.252.138",
                    "organization-display-name" : "ESnet"
-                },
-                "archives" : [
-                   "198.129.252.138"
-                ]
+                }
             },
        "psonar-bw.hpc.osc.edu" : {
           "_meta" : {
@@ -14896,19 +11808,13 @@
           "_meta" : {
              "display-name" : "ps-dev-netlab-1.es.net",
              "organization-display-name" : "ESnet"
-          },
-          "archives" : [
-             "lbnl59-ps-tp.es.net"
-          ]
+          }
        },
       "134.197.113.17" : {
          "_meta" : {
             "display-name" : "134.197.113.17",
             "organization-display-name" : "University of Nevada, Reno"
          },
-         "archives" : [
-            "134.197.113.17"
-         ],
          "no-agent" : true
       },
       "192.5.180.130" : {
@@ -14916,9 +11822,6 @@
             "display-name" : "192.5.180.130",
             "organization-display-name" : "Argonne National Lab"
          },
-         "archives" : [
-            "192.5.180.130"
-         ],
          "no-agent" : true
       },
       "55m-ps.sox.net" : {
@@ -14927,9 +11830,6 @@
             "organization-display-name" : "Southern Crossroads (SOX)",
             "site-display-name" : "Southern Crossroads (SOX)"
          },
-         "archives" : [
-            "55m-ps.sox.net"
-         ],
          "no-agent" : true
       },
       "56m-ps-4x10.sox.net" : {
@@ -14937,9 +11837,6 @@
             "display-name" : "56m-ps-4x10.sox.net",
             "organization-display-name" : "Southern Crossroads (SoX)"
          },
-         "archives" : [
-            "56m-ps-4x10.sox.net"
-         ],
          "no-agent" : true
       },
       "64.71.82.222" : {
@@ -14948,9 +11845,6 @@
             "organization-display-name" : "TAMU CC",
             "site-display-name" : "Texas A&M CC Firewall"
          },
-         "archives" : [
-            "64.71.82.222"
-         ],
          "no-agent" : true
       },
       "65.254.110.185" : {
@@ -14959,9 +11853,6 @@
             "organization-display-name" : "Washington University in St. Louis (WUSTL)",
             "site-display-name" : "WUSTL Inside Firewall"
          },
-         "archives" : [
-            "65.254.110.185"
-         ],
          "no-agent" : true
       },
       "65.254.110.193" : {
@@ -14970,9 +11861,6 @@
             "organization-display-name" : "Washington University in St. Louis (WUSTL)",
             "site-display-name" : "WUSTL Outside Firewall"
          },
-         "archives" : [
-            "65.254.110.193"
-         ],
          "no-agent" : true
       },
       "CNGI-6IX_in_Beijing_IPv4" : {
@@ -14981,9 +11869,6 @@
             "organization-display-name" : "CNGI-6IX in Beijing (IPv4)",
             "site-display-name" : "CNGI-6IX in Beijing (IPv4)"
          },
-         "archives" : [
-            "210.25.189.78"
-         ],
          "no-agent" : true
       },
       "CNGI-6IX_in_Beijing_IPv6" : {
@@ -14992,9 +11877,6 @@
             "organization-display-name" : "CNGI-6IX in Beijing (IPv6)",
             "site-display-name" : "CNGI-6IX in Beijing (IPv6)"
          },
-         "archives" : [
-            "2001:252:0:304:"
-         ],
          "no-agent" : true
       },
       "CNGI-6IX_in_LA_IPv4" : {
@@ -15003,9 +11885,6 @@
             "organization-display-name" : "CNGI-6IX in LA (IPv4)",
             "site-display-name" : "CNGI-6IX in LA (IPv4)"
          },
-         "archives" : [
-            "210.25.189.178"
-         ],
          "no-agent" : true
       },
       "CNGI-6IX_in_LA_IPv6" : {
@@ -15014,9 +11893,6 @@
             "organization-display-name" : "CNGI-6IX in LA (IPv6)",
             "site-display-name" : "CNGI-6IX in LA (IPv6)"
          },
-         "archives" : [
-            "2001:252:0:512:"
-         ],
          "no-agent" : true
       },
       "CSTNET_Computer_Network_Information_Center_CAS_-_IPv4" : {
@@ -15025,9 +11901,6 @@
             "organization-display-name" : "CSTNET (Computer Network Information Center, CAS) - IPv4",
             "site-display-name" : "CSTNET (Computer Network Information Center, CAS) - IPv4"
          },
-         "archives" : [
-            "159.226.253.242"
-         ],
          "no-agent" : true
       },
       "CSTNET_Computer_Network_Information_Center_CAS_-_IPv6" : {
@@ -15036,9 +11909,6 @@
             "organization-display-name" : "CSTNET (Computer Network Information Center, CAS) - IPv6",
             "site-display-name" : "CSTNET (Computer Network Information Center, CAS) - IPv6"
          },
-         "archives" : [
-            "2400:dd01:1010:101:f24d:a2ff:fe70:12a8"
-         ],
          "no-agent" : true
       },
       "GEANT_Amsterdam" : {
@@ -15046,10 +11916,6 @@
             "display-name" : "GEANT Amsterdam",
             "organization-display-name" : "GEANT"
          },
-         "archives" : [
-            "psmp-gn-owd-01.ams-nl.geant.net:",
-            "psmp-gn-bw-01-ams-nl.geant.net:"
-         ],
          "no-agent" : true
       },
       "GEANT_Frankfurt" : {
@@ -15057,10 +11923,6 @@
             "display-name" : "GEANT Frankfurt",
             "organization-display-name" : "GEANT"
          },
-         "archives" : [
-            "psmp-gn-owd-01.fra-de.geant.net:",
-            "psmp-gn-bw-01-fra-de.geant.net:"
-         ],
          "no-agent" : true
       },
       "GEANT_Geneva" : {
@@ -15068,10 +11930,6 @@
             "display-name" : "GEANT Geneva",
             "organization-display-name" : "GEANT"
          },
-         "archives" : [
-            "psmp-gn-bw-01-gen.ch.geant.net:",
-            "psmp-gn-owd-01.gen.ch.geant.net:"
-         ],
          "no-agent" : true
       },
       "GEANT_Paris" : {
@@ -15079,10 +11937,6 @@
             "display-name" : "GEANT Paris",
             "organization-display-name" : "GEANT"
          },
-         "archives" : [
-            "psmp-gn-bw-01-par-fr.geant.net:",
-            "psmp-gn-owd-01.par-fr.geant.net:"
-         ],
          "no-agent" : true
       },
       "IPAC-IMSS__Caltech_PRP" : {
@@ -15091,9 +11945,6 @@
             "organization-display-name" : "Caltech",
             "site-display-name" : "IPAC-IMSS @ Caltech (PRP)"
          },
-         "archives" : [
-            "192.84.86.210"
-         ],
          "no-agent" : true
       },
       "IPAC-IMSS__Caltech_Public" : {
@@ -15102,9 +11953,6 @@
             "organization-display-name" : "Caltech",
             "site-display-name" : "IPAC-IMSS @ Caltech (Public)"
          },
-         "archives" : [
-            "192.12.19.99"
-         ],
          "no-agent" : true
       },
       "Idaho_State_University_BWCTL" : {
@@ -15113,9 +11961,6 @@
             "organization-display-name" : "Idaho State University",
             "site-display-name" : "Idaho State University"
          },
-         "archives" : [
-            "134.50.221.1"
-         ],
          "no-agent" : true
       },
       "Idaho_State_University_OWAMP" : {
@@ -15124,9 +11969,6 @@
             "organization-display-name" : "Idaho State University",
             "site-display-name" : "Idaho State University"
          },
-         "archives" : [
-            "134.50.221.65"
-         ],
          "no-agent" : true
       },
       "PS-1G-v4-FFX-SDMZ.gmu.edu" : {
@@ -15135,9 +11977,6 @@
             "organization-display-name" : "George Mason University",
             "site-display-name" : "George Mason University"
          },
-         "archives" : [
-            "PS-1G-v4-FFX-SDMZ.gmu.edu"
-         ],
          "no-agent" : true
       },
       "updc4.rtm.tns.its.psu.edu" : {
@@ -15146,9 +11985,6 @@
             "organization-display-name" : "The Pennsylvania State University",
             "site-display-name" : "PSU Border Router"
          },
-         "archives" : [
-            "updc4.rtm.tns.its.psu.edu"
-         ],
          "no-agent" : true
       },
       "RedCLARA_Miami" : {
@@ -15156,9 +11992,6 @@
             "display-name" : "RedCLARA Miami",
             "organization-display-name" : "RedCLARA"
          },
-         "archives" : [
-            "200.0.207.49"
-         ],
          "no-agent" : true
       },
       "University_of_Utah_CHPC" : {
@@ -15166,9 +11999,6 @@
             "display-name" : "University of Utah CHPC",
             "organization-display-name" : "University of Utah CHPC"
          },
-         "archives" : [
-            "204.99.128.11"
-         ],
          "no-agent" : true
       },
       "University_of_Wyoming_40G" : {
@@ -15176,9 +12006,6 @@
             "display-name" : "University of Wyoming 40G",
             "organization-display-name" : "University of Wyoming"
          },
-         "archives" : [
-            "198.59.193.60"
-         ],
          "no-agent" : true
       },
       "act-actn-ps1.aarnet.net.au" : {
@@ -15187,9 +12014,6 @@
             "organization-display-name" : "AARNet",
             "site-display-name" : "Canberra, AU"
          },
-         "archives" : [
-            "act-actn-ps1.aarnet.net.au"
-         ],
          "no-agent" : true
       },
       "ah-bonsai-perfsonar.bonsai.uoregon.edu" : {
@@ -15197,37 +12021,25 @@
             "display-name" : "ah-bonsai-perfsonar.bonsai.uoregon.edu",
             "organization-display-name" : "University of Oregon (bonsai)"
          },
-         "archives" : [
-            "ah-bonsai-perfsonar.bonsai.uoregon.edu"
-         ],
          "no-agent" : true
       },
       "albq-pt1.es.net" : {
          "_meta" : {
             "display-name" : "albq-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "albq-pt1.es.net"
-         ]
+         }
       },
       "ameslab-pt1.es.net" : {
          "_meta" : {
             "display-name" : "ameslab-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "ameslab-pt1.es.net"
-         ]
+         }
       },
       "ams-hbn-10g.perfsonar.ac.za" : {
          "_meta" : {
             "display-name" : "ams-hbn-10g.perfsonar.ac.za",
             "organization-display-name" : "SANReN (Hibernia Networks), Amsterdam, North Holland, NL"
          },
-         "archives" : [
-            "ams-hbn-10g.perfsonar.ac.za"
-         ],
          "no-agent" : true
       },
       "ams-hbn-1g.perfsonar.ac.za" : {
@@ -15235,56 +12047,38 @@
             "display-name" : "ams-hbn-1g.perfsonar.ac.za",
             "organization-display-name" : "SANReN (Hibernia Networks), Amsterdam, North Holland, NL"
          },
-         "archives" : [
-            "ams-hbn-1g.perfsonar.ac.za"
-         ],
          "no-agent" : true
       },
       "amst-pt1.es.net" : {
          "_meta" : {
             "display-name" : "amst-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "amst-pt1.es.net"
-         ]
+         }
       },
       "anl-pt1.es.net" : {
          "_meta" : {
             "display-name" : "anl-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "anl-pt1.es.net"
-         ]
+         }
       },
       "anlborder-ps.it.anl.gov" : {
          "_meta" : {
             "display-name" : "anlborder-ps.it.anl.gov",
             "organization-display-name" : "Argonne National Lab"
          },
-         "archives" : [
-            "anlborder-ps.it.anl.gov"
-         ],
          "no-agent" : true
       },
       "antg-staging.es.net" : {
          "_meta" : {
             "display-name" : "antg-staging.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "lbnl59-ps-tp.es.net"
-         ]
+         }
       },
       "bcdc-gw-40g-ps.gatech.edu" : {
          "_meta" : {
             "display-name" : "bcdc-gw-40g-ps.gatech.edu",
             "organization-display-name" : "Georgia Tech"
          },
-         "archives" : [
-            "bcdc-gw-40g-ps.gatech.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.llnl.gov" : {
@@ -15292,9 +12086,6 @@
             "display-name" : "perfsonar.llnl.gov",
             "organization-display-name" : "LLNL"
          },
-         "archives" : [
-            "perfsonar.llnl.gov"
-         ],
          "no-agent" : true
       },
       "bwctl-10g-ps.singaren.net.sg" : {
@@ -15302,9 +12093,6 @@
             "display-name" : "bwctl-10g-ps.singaren.net.sg",
             "organization-display-name" : "bwctl-10g-ps.singaren.net.sg"
          },
-         "archives" : [
-            "bwctl-10g-ps.singaren.net.sg"
-         ],
          "no-agent" : true
       },
       "cal-perfsonar-10g-v6.usc.edu" : {
@@ -15313,9 +12101,6 @@
             "organization-display-name" : "USC In Los Angeles , California (IPv6, 1G)",
             "site-display-name" : "USC In Los Angeles , California (IPv6, 1G)"
          },
-         "archives" : [
-            "cal-perfsonar-10g-v6.usc.edu"
-         ],
          "no-agent" : true
       },
       "cal-perfsonar-10g.usc.edu" : {
@@ -15324,9 +12109,6 @@
             "organization-display-name" : "USC In Los Angeles , California (IPv4)",
             "site-display-name" : "USC In Los Angeles , California (IPv4)"
          },
-         "archives" : [
-            "cal-perfsonar-10g.usc.edu"
-         ],
          "no-agent" : true
       },
       "cc-bonsai-perfsonar.bonsai.uoregon.edu" : {
@@ -15334,9 +12116,6 @@
             "display-name" : "cc-bonsai-perfsonar.bonsai.uoregon.edu",
             "organization-display-name" : "University of Oregon (bonsai)"
          },
-         "archives" : [
-            "cc-bonsai-perfsonar.bonsai.uoregon.edu"
-         ],
          "no-agent" : true
       },
       "ccperfsonar1.in2p3.fr" : {
@@ -15344,9 +12123,6 @@
             "display-name" : "ccperfsonar1.in2p3.fr",
             "organization-display-name" : "IN2P3 in Lyon FR"
          },
-         "archives" : [
-            "ccperfsonar1.in2p3.fr"
-         ],
          "no-agent" : true
       },
       "ccperfsonar2.in2p3.fr" : {
@@ -15354,9 +12130,6 @@
             "display-name" : "ccperfsonar2.in2p3.fr",
             "organization-display-name" : "IN2P3 in Lyon FR"
          },
-         "archives" : [
-            "ccperfsonar2.in2p3.fr"
-         ],
          "no-agent" : true
       },
       "cl-perfsonar0-prod.cssd.pitt.edu" : {
@@ -15364,9 +12137,6 @@
             "display-name" : "cl-perfsonar0-prod.cssd.pitt.edu",
             "organization-display-name" : "cl-perfsonar0-prod.cssd.pitt.edu"
          },
-         "archives" : [
-            "cl-perfsonar0-prod.cssd.pitt.edu"
-         ],
          "no-agent" : true
       },
       "cpt-is-10g.perfsonar.ac.za" : {
@@ -15374,9 +12144,6 @@
             "display-name" : "cpt-is-10g.perfsonar.ac.za",
             "organization-display-name" : "SANReN , Cape Town , Western Cape , ZA"
          },
-         "archives" : [
-            "cpt-is-10g.perfsonar.ac.za"
-         ],
          "no-agent" : true
       },
       "cpt-is-1g.perfsonar.ac.za" : {
@@ -15384,9 +12151,6 @@
             "display-name" : "cpt-is-1g.perfsonar.ac.za",
             "organization-display-name" : "SANReN , Cape Town , Western Cape , ZA"
          },
-         "archives" : [
-            "cpt-is-1g.perfsonar.ac.za"
-         ],
          "no-agent" : true
       },
       "cpt-teraco-10g.perfsonar.ac.za" : {
@@ -15394,9 +12158,6 @@
             "display-name" : "cpt-teraco-10g.perfsonar.ac.za",
             "organization-display-name" : "cpt-teraco-10g.perfsonar.ac.za"
          },
-         "archives" : [
-            "cpt-teraco-10g.perfsonar.ac.za"
-         ],
          "no-agent" : true
       },
       "cs-perfsonar-2.cs.wisc.edu" : {
@@ -15404,9 +12165,6 @@
             "display-name" : "cs-perfsonar-2.cs.wisc.edu",
             "organization-display-name" : "cs-perfsonar-2.cs.wisc.edu"
          },
-         "archives" : [
-            "cs-perfsonar-2.cs.wisc.edu"
-         ],
          "no-agent" : true
       },
       "dps10.ucsc.edu" : {
@@ -15414,9 +12172,6 @@
             "display-name" : "dps10.ucsc.edu",
             "organization-display-name" : "dps10.ucsc.edu"
          },
-         "archives" : [
-            "dps10.ucsc.edu"
-         ],
          "no-agent" : true
       },
       "drperfsonar.fiu.edu" : {
@@ -15424,9 +12179,6 @@
             "display-name" : "drperfsonar.fiu.edu",
             "organization-display-name" : "drperfsonar.fiu.edu"
          },
-         "archives" : [
-            "drperfsonar.fiu.edu"
-         ],
          "no-agent" : true
       },
       "dspex2-dmz.idies.jhu.edu" : {
@@ -15435,9 +12187,6 @@
             "organization-display-name" : "John Hopkins University",
             "site-display-name" : "John Hopkins University"
          },
-         "archives" : [
-            "dspex2-dmz.idies.jhu.edu"
-         ],
          "no-agent" : true
       },
       "du-perfsonar-outside.du.edu" : {
@@ -15445,9 +12194,6 @@
             "display-name" : "du-perfsonar-outside.du.edu",
             "organization-display-name" : "University Of Denver"
          },
-         "archives" : [
-            "du-perfsonar-outside.du.edu"
-         ],
          "no-agent" : true
       },
       "ec-perfsonar.earlham.edu" : {
@@ -15455,9 +12201,6 @@
             "display-name" : "ec-perfsonar.earlham.edu",
             "organization-display-name" : "ec-perfsonar.earlham.edu"
          },
-         "archives" : [
-            "ec-perfsonar.earlham.edu"
-         ],
          "no-agent" : true
       },
       "epgperf.ph.bham.ac.uk" : {
@@ -15465,46 +12208,31 @@
             "display-name" : "epgperf.ph.bham.ac.uk",
             "organization-display-name" : "UKI-SOUTHGRID-BHAM-HEP"
          },
-         "archives" : [
-            "epgperf.ph.bham.ac.uk"
-         ],
          "no-agent" : true
       },
       "eqx-ash-pt1.es.net" : {
          "_meta" : {
             "display-name" : "eqx-ash-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "eqx-ash-pt1.es.net"
-         ]
+         }
       },
       "eqx-chi-pt1.es.net" : {
          "_meta" : {
             "display-name" : "eqx-chi-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "eqx-chi-pt1.es.net"
-         ]
+         }
       },
       "eqx-sj-pt1.es.net" : {
          "_meta" : {
             "display-name" : "eqx-sj-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "eqx-sj-pt1.es.net"
-         ]
+         }
       },
       "fiona-01.rdi2.rutgers.edu" : {
          "_meta" : {
             "display-name" : "fiona-01.rdi2.rutgers.edu",
             "organization-display-name" : "fiona-01.rdi2.rutgers.edu"
          },
-         "archives" : [
-            "fiona-01.rdi2.rutgers.edu"
-         ],
          "no-agent" : true
       },
       "fiona-40g.ucsc.edu" : {
@@ -15512,9 +12240,6 @@
             "display-name" : "fiona-40g.ucsc.edu",
             "organization-display-name" : "Fiona Project"
          },
-         "archives" : [
-            "fiona-40g.ucsc.edu"
-         ],
          "no-agent" : true
       },
       "fiona-ps.net.berkeley.edu" : {
@@ -15522,9 +12247,6 @@
             "display-name" : "fiona-ps.net.berkeley.edu",
             "organization-display-name" : "fiona-ps.net.berkeley.edu"
          },
-         "archives" : [
-            "fiona-ps.net.berkeley.edu"
-         ],
          "no-agent" : true
       },
       "fiona-ps.ucsc.edu" : {
@@ -15532,9 +12254,6 @@
             "display-name" : "fiona-ps.ucsc.edu",
             "organization-display-name" : "University of California Santa Cruz"
          },
-         "archives" : [
-            "fiona-ps.ucsc.edu"
-         ],
          "no-agent" : true
       },
       "fiona.tools.ucla.net" : {
@@ -15542,9 +12261,6 @@
             "display-name" : "fiona.tools.ucla.net",
             "organization-display-name" : "University of California Los Angeles"
          },
-         "archives" : [
-            "fiona.tools.ucla.net"
-         ],
          "no-agent" : true
       },
       "ga-eastdtn-ps.gat.com" : {
@@ -15553,9 +12269,6 @@
             "organization-display-name" : "EAST DTN at GA in San Diego, CA (IPv4)",
             "site-display-name" : "EAST DTN at GA in San Diego, CA (IPv4)"
          },
-         "archives" : [
-            "ga-eastdtn-ps.gat.com"
-         ],
          "no-agent" : true
       },
       "hcc-ps01.unl.edu" : {
@@ -15564,9 +12277,6 @@
             "organization-display-name" : "University of Nebraska, Lincoln",
             "site-display-name" : "University of Nebraska, Lincoln"
          },
-         "archives" : [
-            "hcc-ps01.unl.edu"
-         ],
          "no-agent" : true
       },
       "hcc-ps02.unl.edu" : {
@@ -15575,9 +12285,6 @@
             "organization-display-name" : "University of Nebraska, Lincoln",
             "site-display-name" : "University of Nebraska, Lincoln"
          },
-         "archives" : [
-            "hcc-ps02.unl.edu"
-         ],
          "no-agent" : true
       },
       "hive02.swarm.uhnet.net" : {
@@ -15591,19 +12298,13 @@
          "_meta" : {
             "display-name" : "hous-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "hous-pt1.es.net"
-         ]
+         }
       },
       "hulkenberg.noc.unf.edu" : {
          "_meta" : {
             "display-name" : "hulkenberg.noc.unf.edu",
             "organization-display-name" : "hulkenberg.noc.unf.edu"
          },
-         "archives" : [
-            "hulkenberg.noc.unf.edu"
-         ],
          "no-agent" : true
       },
       "isu-ps-001.indstate.edu" : {
@@ -15611,9 +12312,6 @@
             "display-name" : "isu-ps-001.indstate.edu",
             "organization-display-name" : "isu-ps-001.indstate.edu"
          },
-         "archives" : [
-            "isu-ps-001.indstate.edu"
-         ],
          "no-agent" : true
       },
       "its-perfmon.syr.edu" : {
@@ -15621,9 +12319,6 @@
             "display-name" : "its-perfmon.syr.edu",
             "organization-display-name" : "its-perfmon.syr.edu"
          },
-         "archives" : [
-            "its-perfmon.syr.edu"
-         ],
          "no-agent" : true
       },
       "jed-scdmz-perfsonar01.kaust.edu.sa" : {
@@ -15631,19 +12326,13 @@
             "display-name" : "jed-scdmz-perfsonar01.kaust.edu.sa",
             "organization-display-name" : "KAUST perfSONAR"
          },
-         "archives" : [
-            "jed-scdmz-perfsonar01.kaust.edu.sa"
-         ],
          "no-agent" : true
       },
       "jgi-pt1.es.net" : {
          "_meta" : {
             "display-name" : "jgi-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "jgi-pt1.es.net"
-         ]
+         }
       },
       "jlab4.jlab.org" : {
          "_meta" : {
@@ -15651,19 +12340,13 @@
             "organization-display-name" : "JLAB",
             "site-display-name" : "JLAB"
          },
-         "archives" : [
-            "jlab4.jlab.org"
-         ],
          "no-agent" : true
       },
       "kans-pt1.es.net" : {
          "_meta" : {
             "display-name" : "kans-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "kans-pt1.es.net"
-         ]
+         }
       },
       "kstar-ps.nfri.re.kr" : {
          "_meta" : {
@@ -15671,28 +12354,19 @@
             "organization-display-name" : "NFRI",
             "site-display-name" : "NFRI"
          },
-         "archives" : [
-            "134.75.85.126"
-         ],
          "no-agent" : true
       },
       "lbnl59-ps-tp.es.net" : {
          "_meta" : {
             "display-name" : "lbnl59-ps-tp.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "lbnl59-ps-tp.es.net"
-         ]
+         }
       },
       "lhc-bandwidth.twgrid.org" : {
          "_meta" : {
             "display-name" : "lhc-bandwidth.twgrid.org",
             "organization-display-name" : "ASGC"
          },
-         "archives" : [
-            "lhc-bandwidth.twgrid.org"
-         ],
          "no-agent" : true
       },
       "lhcmon.bnl.gov" : {
@@ -15700,9 +12374,6 @@
             "display-name" : "lhcmon.bnl.gov",
             "organization-display-name" : "Brookhaven National Lab"
          },
-         "archives" : [
-            "lhcmon.bnl.gov"
-         ],
          "no-agent" : true
       },
       "lhcperfmon.bnl.gov" : {
@@ -15710,9 +12381,6 @@
             "display-name" : "lhcperfmon.bnl.gov",
             "organization-display-name" : "Brookhaven National Lab"
          },
-         "archives" : [
-            "lhcperfmon.bnl.gov"
-         ],
          "no-agent" : true
       },
       "lhcmon3.bnl.gov" : {
@@ -15720,9 +12388,6 @@
             "display-name" : "lhcmon3.bnl.gov",
             "organization-display-name" : "Brookhaven National Lab"
          },
-         "archives" : [
-            "lhcmon3.bnl.gov"
-         ],
          "no-agent" : true
       },
       "m-cssc-b380-11.net.wisc.edu" : {
@@ -15730,9 +12395,6 @@
             "display-name" : "m-cssc-b380-11.net.wisc.edu",
             "organization-display-name" : "University of Wisconsin"
          },
-         "archives" : [
-            "m-cssc-b380-11.net.wisc.edu"
-         ],
          "no-agent" : true
       },
       "m-cssc-b380-12.net.wisc.edu" : {
@@ -15740,9 +12402,6 @@
             "display-name" : "m-cssc-b380-12.net.wisc.edu",
             "organization-display-name" : "University of Wisconsin"
          },
-         "archives" : [
-            "m-cssc-b380-12.net.wisc.edu"
-         ],
          "no-agent" : true
       },
       "mcc-perfsonar-10g-v6.usc.edu" : {
@@ -15751,9 +12410,6 @@
             "organization-display-name" : "USC (Border) In Los Angeles , California (IPv6, 10G)",
             "site-display-name" : "USC (Border) In Los Angeles , California (IPv6, 10G)"
          },
-         "archives" : [
-            "mcc-perfsonar-10g-v6.usc.edu"
-         ],
          "no-agent" : true
       },
       "mcc-perfsonar-10g.usc.edu" : {
@@ -15762,9 +12418,6 @@
             "organization-display-name" : "USC (Border) In Los Angeles , California (IPv4, 10G)",
             "site-display-name" : "USC (Border) In Los Angeles , California (IPv4, 10G)"
          },
-         "archives" : [
-            "mcc-perfsonar-10g.usc.edu"
-         ],
          "no-agent" : true
       },
       "mcc-perfsonar-1g-v6.usc.edu" : {
@@ -15773,9 +12426,6 @@
             "organization-display-name" : "USC (Border) In Los Angeles , California (IPv6, 1G)",
             "site-display-name" : "USC (Border) In Los Angeles , California (IPv6, 1G)"
          },
-         "archives" : [
-            "mcc-perfsonar-1g-v6.usc.edu"
-         ],
          "no-agent" : true
       },
       "mcc-perfsonar-1g.usc.edu" : {
@@ -15784,9 +12434,6 @@
             "organization-display-name" : "USC (Border) In Los Angeles , California (IPv4, 1G)",
             "site-display-name" : "USC (Border) In Los Angeles , California (IPv4, 1G)"
          },
-         "archives" : [
-            "mcc-perfsonar-1g.usc.edu"
-         ],
          "no-agent" : true
       },
       "mcln-ps.maxgigapop.net" : {
@@ -15795,9 +12442,6 @@
             "organization-display-name" : "Mid-Atlantic Crossroads (MAX)",
             "site-display-name" : "Mid-Atlantic Crossroads (MAX)"
          },
-         "archives" : [
-            "mcln-ps.maxgigapop.net"
-         ],
          "no-agent" : true
       },
       "mgalbre.jhh.jhu.edu" : {
@@ -15806,9 +12450,6 @@
             "organization-display-name" : "John Hopkins University",
             "site-display-name" : "John Hopkins University"
          },
-         "archives" : [
-            "mgalbre.jhh.jhu.edu"
-         ],
          "no-agent" : true
       },
       "monipe-sp-mpatraso.rnp.br" : {
@@ -15817,9 +12458,6 @@
             "organization-display-name" : "RNP Brazil",
             "site-display-name" : "RNP Brazil (Sao Paulo)"
          },
-         "archives" : [
-            "monipe-sp-mpatraso.rnp.br"
-         ],
          "no-agent" : true
       },
       "monipe-sp-mpbanda.rnp.br" : {
@@ -15828,9 +12466,6 @@
             "organization-display-name" : "RNP Brazil",
             "site-display-name" : "RNP Brazil (Sao Paulo)"
          },
-         "archives" : [
-            "monipe-sp-mpbanda.rnp.br"
-         ],
          "no-agent" : true
       },
       "monipe-sp-portal.rnp.br" : {
@@ -15839,9 +12474,6 @@
             "organization-display-name" : "RNP Brazil",
             "site-display-name" : "RNP Brazil (Sao Paulo)"
          },
-         "archives" : [
-            "monipe-sp-portal.rnp.br"
-         ],
          "no-agent" : true
       },
       "mplex-ps.sox.net" : {
@@ -15849,37 +12481,25 @@
             "display-name" : "mplex-ps.sox.net",
             "organization-display-name" : "mplex-ps.sox.net"
          },
-         "archives" : [
-            "mplex-ps.sox.net"
-         ],
          "no-agent" : true
       },
       "mwt2-ps02.campuscluster.illinois.edu" : {
          "_meta" : {
             "organization-display-name" : "National Center for Supercomputing Applications"
          },
-         "archives" : [
-            "mwt2-ps02.campuscluster.illinois.edu"
-         ],
          "no-agent" : true
       },
       "nash-pt1.es.net" : {
          "_meta" : {
             "display-name" : "nash-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "nash-pt1.es.net"
-         ]
+         }
       },
       "nate.sdsc.edu" : {
          "_meta" : {
             "display-name" : "nate.sdsc.edu",
             "organization-display-name" : "San Diego Supercomputer Center"
          },
-         "archives" : [
-            "nate.sdsc.edu"
-         ],
          "no-agent" : true
       },
       "ndt.crc.nd.edu" : {
@@ -15887,9 +12507,6 @@
             "display-name" : "ndt.crc.nd.edu",
             "organization-display-name" : "ndt.crc.nd.edu"
          },
-         "archives" : [
-            "ndt.crc.nd.edu"
-         ],
          "no-agent" : true
       },
       "ndt.itcc.unc.edu" : {
@@ -15897,9 +12514,6 @@
             "display-name" : "ndt.itcc.unc.edu",
             "organization-display-name" : "The University of North Carolina, Chapel Hill"
          },
-         "archives" : [
-            "ndt.itcc.unc.edu"
-         ],
          "no-agent" : true
       },
       "nettest-outside.it.wsu.edu" : {
@@ -15907,9 +12521,6 @@
             "display-name" : "nettest-outside.it.wsu.edu",
             "organization-display-name" : "Washington State University"
          },
-         "archives" : [
-            "nettest-outside.it.wsu.edu"
-         ],
          "no-agent" : true
       },
       "nettest.boulder.noaa.gov" : {
@@ -15917,9 +12528,6 @@
             "display-name" : "nettest.boulder.noaa.gov",
             "organization-display-name" : "NOAA"
          },
-         "archives" : [
-            "nettest.boulder.noaa.gov"
-         ],
          "no-agent" : true
       },
       "nettest.it.wsu.edu" : {
@@ -15927,9 +12535,6 @@
             "display-name" : "nettest.it.wsu.edu",
             "organization-display-name" : "nettest.it.wsu.edu"
          },
-         "archives" : [
-            "nettest.it.wsu.edu"
-         ],
          "no-agent" : true
       },
       "netw-ps1.stanford.edu" : {
@@ -15937,28 +12542,19 @@
             "display-name" : "netw-ps1.stanford.edu",
             "organization-display-name" : "Stanford"
          },
-         "archives" : [
-            "netw-ps1.stanford.edu"
-         ],
          "no-agent" : true
       },
       "newy-pt1.es.net" : {
          "_meta" : {
             "display-name" : "newy-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "newy-pt1.es.net"
-         ]
+         }
       },
       "nkn-inl-perfsonar.nkn.uidaho.edu" : {
          "_meta" : {
             "display-name" : "nkn-inl-perfsonar.nkn.uidaho.edu",
             "organization-display-name" : "University of Idaho (NKN)"
          },
-         "archives" : [
-            "nkn-inl-perfsonar.nkn.uidaho.edu"
-         ],
          "no-agent" : true
       },
       "nmon-msu.mich.net" : {
@@ -15966,9 +12562,6 @@
             "display-name" : "nmon-msu.mich.net",
             "organization-display-name" : "nmon-msu.mich.net"
          },
-         "archives" : [
-            "nmon-msu.mich.net"
-         ],
          "no-agent" : true
       },
       "nms1-10g.jp.apan.net" : {
@@ -15976,9 +12569,6 @@
             "display-name" : "nms1-10g.jp.apan.net",
             "organization-display-name" : "APAN"
          },
-         "archives" : [
-            "nms1-10g.jp.apan.net"
-         ],
          "no-agent" : true
       },
       "nms4.jp.apan.net" : {
@@ -15986,19 +12576,13 @@
             "display-name" : "nms4.jp.apan.net",
             "organization-display-name" : "APAN"
          },
-         "archives" : [
-            "nms4.jp.apan.net"
-         ],
          "no-agent" : true
       },
       "nso-opt1.es.net" : {
          "_meta" : {
             "display-name" : "nso-opt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "nso-pt1.es.net"
-         ]
+         }
       },
       "nsw-brwy-ps1.aarnet.net.au" : {
          "_meta" : {
@@ -16006,9 +12590,6 @@
             "organization-display-name" : "AARNet",
             "site-display-name" : "New South Wales, AU"
          },
-         "archives" : [
-            "nsw-brwy-ps1.aarnet.net.au"
-         ],
          "no-agent" : true
       },
       "ntg-perfsonar2.services.brown.edu" : {
@@ -16016,9 +12597,6 @@
             "display-name" : "ntg-perfsonar2.services.brown.edu",
             "organization-display-name" : "Brown University"
          },
-         "archives" : [
-            "ntg-perfsonar2.services.brown.edu"
-         ],
          "no-agent" : true
       },
       "ntg-perfsonar4.services.brown.edu" : {
@@ -16026,9 +12604,6 @@
             "display-name" : "ntg-perfsonar4.services.brown.edu",
             "organization-display-name" : "Brown University"
          },
-         "archives" : [
-            "ntg-perfsonar4.services.brown.edu"
-         ],
          "no-agent" : true
       },
       "nysernet1-ps.net.cornell.edu" : {
@@ -16036,37 +12611,25 @@
             "display-name" : "nysernet1-ps.net.cornell.edu",
             "organization-display-name" : "nysernet1-ps.net.cornell.edu"
          },
-         "archives" : [
-            "nysernet1-ps.net.cornell.edu"
-         ],
          "no-agent" : true
       },
       "orau-opt1.es.net" : {
          "_meta" : {
             "display-name" : "orau-opt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "orau-pt1.es.net"
-         ]
+         }
       },
       "ornl-pt1.es.net" : {
          "_meta" : {
             "display-name" : "ornl-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "ornl-pt1.es.net"
-         ]
+         }
       },
       "owamp-scz.pnl.gov" : {
          "_meta" : {
             "display-name" : "owamp-scz.pnl.gov",
             "organization-display-name" : "PNNL"
          },
-         "archives" : [
-            "owamp-scz.pnl.gov"
-         ],
          "no-agent" : true
       },
       "pas-adhoc.chic.net.internet2.edu" : {
@@ -16074,9 +12637,6 @@
             "display-name" : "pas-adhoc.chic.net.internet2.edu",
             "organization-display-name" : "Internet2"
          },
-         "archives" : [
-            "pas-adhoc.chic.net.internet2.edu"
-         ],
          "no-agent" : true
       },
       "pas-adhoc.newy32aoa.net.internet2.edu" : {
@@ -16084,9 +12644,6 @@
             "display-name" : "pas-adhoc.newy32aoa.net.internet2.edu",
             "organization-display-name" : "Internet2"
          },
-         "archives" : [
-            "pas-adhoc.newy32aoa.net.internet2.edu"
-         ],
          "no-agent" : true
       },
       "pas-adhoc.seat.net.internet2.edu" : {
@@ -16094,9 +12651,6 @@
             "display-name" : "pas-adhoc.seat.net.internet2.edu",
             "organization-display-name" : "Internet2"
          },
-         "archives" : [
-            "pas-adhoc.seat.net.internet2.edu"
-         ],
          "no-agent" : true
       },
       "perf-scidmz-data.cac.washington.edu" : {
@@ -16104,9 +12658,6 @@
             "display-name" : "perf-scidmz-data.cac.washington.edu",
             "organization-display-name" : "perf-scidmz-data.cac.washington.edu"
          },
-         "archives" : [
-            "perf-scidmz-data.cac.washington.edu"
-         ],
          "no-agent" : true
       },
       "perf-unh.unh.edu" : {
@@ -16114,9 +12665,6 @@
             "display-name" : "perf-unh.unh.edu",
             "organization-display-name" : "perf-unh.unh.edu"
          },
-         "archives" : [
-            "perf-unh.unh.edu"
-         ],
          "no-agent" : true
       },
       "perf-v6.hfcas.ac.cn" : {
@@ -16125,9 +12673,6 @@
             "organization-display-name" : "HFCAS in China (IPv6)",
             "site-display-name" : "HFCAS in China (IPv6)"
          },
-         "archives" : [
-            "perf-v6.hfcas.ac.cn"
-         ],
          "no-agent" : true
       },
       "perf-v6.ipp.ac.cn" : {
@@ -16136,9 +12681,6 @@
             "organization-display-name" : "IPP in Hefei, Anhui, China (IPv6)",
             "site-display-name" : "PP in Hefei, Anhui, China (IPv6)"
          },
-         "archives" : [
-            "perf-v6.ipp.ac.cn"
-         ],
          "no-agent" : true
       },
       "perf.hfcas.ac.cn" : {
@@ -16147,9 +12689,6 @@
             "organization-display-name" : "HFCAS in China (IPv4)",
             "site-display-name" : "HFCAS in China (IPv4)"
          },
-         "archives" : [
-            "perf.hfcas.ac.cn"
-         ],
          "no-agent" : true
       },
       "perf.ipp.ac.cn" : {
@@ -16158,9 +12697,6 @@
             "organization-display-name" : "IPP in Hefei, Anhui, China (IPv4)",
             "site-display-name" : "IPP in Hefei, Anhui, China (IPv4)"
          },
-         "archives" : [
-            "perf.ipp.ac.cn"
-         ],
          "no-agent" : true
       },
       "perf.stolaf.edu" : {
@@ -16168,9 +12704,6 @@
             "display-name" : "perf.stolaf.edu",
             "organization-display-name" : "perf.stolaf.edu"
          },
-         "archives" : [
-            "perf.stolaf.edu"
-         ],
          "no-agent" : true
       },
       "perf0.itrc.txstate.edu" : {
@@ -16178,9 +12711,6 @@
             "display-name" : "perf0.itrc.txstate.edu",
             "organization-display-name" : "perf0.itrc.txstate.edu"
          },
-         "archives" : [
-            "perf0.itrc.txstate.edu"
-         ],
          "no-agent" : true
       },
       "perf10g-tcom.colorado.edu" : {
@@ -16188,9 +12718,6 @@
             "display-name" : "perf10g-tcom.colorado.edu",
             "organization-display-name" : "University of Colorado"
          },
-         "archives" : [
-            "perf10g-tcom.colorado.edu"
-         ],
          "no-agent" : true
       },
       "perfSONAR.myren.net.my" : {
@@ -16199,9 +12726,6 @@
             "organization-display-name" : "Malaysian Research Education Network(MYREN)",
             "site-display-name" : "Cyberjaya,Selangor,Malaysia"
          },
-         "archives" : [
-            "perfSONAR.myren.net.my"
-         ],
          "no-agent" : true
       },
       "perfbsu-temp.boisestate.edu" : {
@@ -16209,9 +12733,6 @@
             "display-name" : "perfbsu-temp.boisestate.edu",
             "organization-display-name" : "Boise State"
          },
-         "archives" : [
-            "perfbsu-temp.boisestate.edu"
-         ],
          "no-agent" : true
       },
       "perfs1-owamp.lanl.gov" : {
@@ -16220,9 +12741,6 @@
             "organization-display-name" : "LANL",
             "site-display-name" : "LANL"
          },
-         "archives" : [
-            "perfs1-owamp.lanl.gov"
-         ],
          "no-agent" : true
       },
       "perfs1.lanl.gov" : {
@@ -16231,9 +12749,6 @@
             "organization-display-name" : "LANL",
             "site-display-name" : "LANL"
          },
-         "archives" : [
-            "perfs1.lanl.gov"
-         ],
          "no-agent" : true
       },
       "perfsonar-10.cv.nrao.edu" : {
@@ -16241,9 +12756,6 @@
             "display-name" : "perfsonar-10.cv.nrao.edu",
             "organization-display-name" : "perfsonar-10.cv.nrao.edu"
          },
-         "archives" : [
-            "perfsonar-10.cv.nrao.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar-1850.frgp.net" : {
@@ -16252,9 +12764,6 @@
             "organization-display-name" : "Front Range GigaPoP (FRGP)",
             "site-display-name" : "Front Range GigaPoP (FRGP)"
          },
-         "archives" : [
-            "perfsonar-1850.frgp.net"
-         ],
          "no-agent" : true
       },
       "perfsonar-bw.sprace.org.br" : {
@@ -16263,9 +12772,6 @@
             "organization-display-name" : "SPRACE",
             "site-display-name" : "SPRACE"
          },
-         "archives" : [
-            "perfsonar-bw.sprace.org.br"
-         ],
          "no-agent" : true
       },
       "perfsonar-bwctl.accre.vanderbilt.edu" : {
@@ -16273,9 +12779,6 @@
             "display-name" : "perfsonar-bwctl.accre.vanderbilt.edu",
             "organization-display-name" : "ACCRE Computing Center at Vanderbilt University"
          },
-         "archives" : [
-            "perfsonar-bwctl.accre.vanderbilt.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar-core-fxb-10ge.umnet.umich.edu" : {
@@ -16283,9 +12786,6 @@
             "display-name" : "perfsonar-core-fxb-10ge.umnet.umich.edu",
             "organization-display-name" : "University of Michigan"
          },
-         "archives" : [
-            "perfsonar-core-fxb-10ge.umnet.umich.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar-corv-core-10g.net.oregonstate.edu" : {
@@ -16293,9 +12793,6 @@
             "display-name" : "perfsonar-corv-core-10g.net.oregonstate.edu",
             "organization-display-name" : "Oregon State University"
          },
-         "archives" : [
-            "perfsonar-corv-core-10g.net.oregonstate.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar-dcw.ohsu.edu" : {
@@ -16303,9 +12800,6 @@
             "display-name" : "perfsonar-dcw.ohsu.edu",
             "organization-display-name" : "Oregon Health Science University"
          },
-         "archives" : [
-            "perfsonar-dcw.ohsu.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar-de-kit.gridka.de" : {
@@ -16313,9 +12807,6 @@
             "display-name" : "perfsonar-de-kit.gridka.de",
             "organization-display-name" : "Karlsruhe Institute of Technology (KIT), Karlsruhe , DE"
          },
-         "archives" : [
-            "perfsonar-de-kit.gridka.de"
-         ],
          "no-agent" : true
       },
       "perfsonar-dmz-10g.georgetown.edu" : {
@@ -16323,9 +12814,6 @@
             "display-name" : "perfsonar-dmz-10g.georgetown.edu",
             "organization-display-name" : "perfsonar-dmz-10g.georgetown.edu"
          },
-         "archives" : [
-            "perfsonar-dmz-10g.georgetown.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar-dmz.marcc.jhu.edu" : {
@@ -16334,9 +12822,6 @@
             "organization-display-name" : "John Hopkins University",
             "site-display-name" : "John Hopkins University"
          },
-         "archives" : [
-            "perfsonar-dmz.marcc.jhu.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar-hartford.cen.ct.gov" : {
@@ -16345,9 +12830,6 @@
             "organization-display-name" : "Connecticut Education Network (CEN)",
             "site-display-name" : "Connecticut Education Network (CEN) Hartford"
          },
-         "archives" : [
-            "perfsonar-hartford.cen.ct.gov"
-         ],
          "no-agent" : true
       },
       "perfsonar-hartford.cen.ct.gov_IPv6" : {
@@ -16356,9 +12838,6 @@
             "organization-display-name" : "Connecticut Education Network (CEN)",
             "site-display-name" : "Connecticut Education Network (CEN) Hartford"
          },
-         "archives" : [
-            "2607:f460:a001:9:"
-         ],
          "no-agent" : true
       },
       "perfsonar-lsu-frey-01.loni.org" : {
@@ -16367,9 +12846,6 @@
             "organization-display-name" : "LONI",
             "site-display-name" : "LONI"
          },
-         "archives" : [
-            "perfsonar-lsu-frey-01.loni.org"
-         ],
          "no-agent" : true
       },
       "perfsonar-lt.sprace.org.br" : {
@@ -16378,9 +12854,6 @@
             "organization-display-name" : "SPRACE",
             "site-display-name" : "SPRACE"
          },
-         "archives" : [
-            "perfsonar-lt.sprace.org.br"
-         ],
          "no-agent" : true
       },
       "perfsonar-net3.uoregon.edu" : {
@@ -16388,9 +12861,6 @@
             "display-name" : "perfsonar-net3.uoregon.edu",
             "organization-display-name" : "perfsonar-net3.uoregon.edu"
          },
-         "archives" : [
-            "perfsonar-net3.uoregon.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar-ow.cnaf.infn.it" : {
@@ -16398,9 +12868,6 @@
             "display-name" : "perfsonar-ow.cnaf.infn.it",
             "organization-display-name" : "INFN-T1"
          },
-         "archives" : [
-            "perfsonar-ow.cnaf.infn.it"
-         ],
          "no-agent" : true
       },
       "perfsonar-owamp.accre.vanderbilt.edu" : {
@@ -16408,9 +12875,6 @@
             "display-name" : "perfsonar-owamp.accre.vanderbilt.edu",
             "organization-display-name" : "ACCRE Computing Center at Vanderbilt University"
          },
-         "archives" : [
-            "perfsonar-owamp.accre.vanderbilt.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar-ps.cnaf.infn.it" : {
@@ -16418,9 +12882,6 @@
             "display-name" : "perfsonar-ps.cnaf.infn.it",
             "organization-display-name" : "INFN-T1"
          },
-         "archives" : [
-            "perfsonar-ps.cnaf.infn.it"
-         ],
          "no-agent" : true
       },
       "perfsonar-sphrack-macc.umnet.umich.edu" : {
@@ -16428,9 +12889,6 @@
             "display-name" : "perfsonar-sphrack-macc.umnet.umich.edu",
             "organization-display-name" : "University of Michigan"
          },
-         "archives" : [
-            "perfsonar-sphrack-macc.umnet.umich.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar-storrs.cen.ct.gov" : {
@@ -16439,9 +12897,6 @@
             "organization-display-name" : "Connecticut Education Network (CEN)",
             "site-display-name" : "Connecticut Education Network (CEN) Storrs"
          },
-         "archives" : [
-            "perfsonar-storrs.cen.ct.gov"
-         ],
          "no-agent" : true
       },
       "perfsonar-storrs.cen.ct.gov_IPv6" : {
@@ -16450,9 +12905,6 @@
             "organization-display-name" : "Connecticut Education Network (CEN)",
             "site-display-name" : "Connecticut Education Network (CEN) Storrs"
          },
-         "archives" : [
-            "2607:f460:a001:13:"
-         ],
          "no-agent" : true
       },
       "perfsonar-test4.kek.jp" : {
@@ -16460,9 +12912,6 @@
             "display-name" : "perfsonar-test4.kek.jp",
             "organization-display-name" : "KEK"
          },
-         "archives" : [
-            "perfsonar-test4.kek.jp"
-         ],
          "no-agent" : true
       },
       "perfsonar-vm01.jc.rl.ac.uk" : {
@@ -16470,9 +12919,6 @@
             "display-name" : "perfsonar-vm01.jc.rl.ac.uk",
             "organization-display-name" : "UK Centre for Environmental Data Archival"
          },
-         "archives" : [
-            "perfsonar-vm01.jc.rl.ac.uk"
-         ],
          "no-agent" : true
       },
       "perfsonar7.dkrz.de" : {
@@ -16480,9 +12926,6 @@
             "display-name" : "perfsonar7.dkrz.de",
             "organization-display-name" : "DKRZ"
          },
-         "archives" : [
-            "perfsonar7.dkrz.de"
-         ],
          "no-agent" : true
       },
       "perfsonar.fsl.byu.edu" : {
@@ -16490,9 +12933,6 @@
             "display-name" : "perfsonar.fsl.byu.edu",
             "organization-display-name" : "Brigham Young University"
          },
-         "archives" : [
-            "perfsonar.fsl.byu.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.gmca.aps.anl.gov" : {
@@ -16500,9 +12940,6 @@
             "display-name" : "perfsonar.gmca.aps.anl.gov",
             "organization-display-name" : "Argonne National Lab"
          },
-         "archives" : [
-            "perfsonar.gmca.aps.anl.gov"
-         ],
          "no-agent" : true
       },
       "perfsonar.hpc.wvu.edu" : {
@@ -16510,9 +12947,6 @@
             "display-name" : "perfsonar.hpc.wvu.edu",
             "organization-display-name" : "perfsonar.hpc.wvu.edu"
          },
-         "archives" : [
-            "perfsonar.hpc.wvu.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.ihep.ac.cn" : {
@@ -16520,9 +12954,6 @@
             "display-name" : "perfsonar.ihep.ac.cn",
             "organization-display-name" : "IHEP"
          },
-         "archives" : [
-            "perfsonar.ihep.ac.cn"
-         ],
          "no-agent" : true
       },
       "perfsonar.its.msstate.edu" : {
@@ -16530,9 +12961,6 @@
             "display-name" : "perfsonar.its.msstate.edu",
             "organization-display-name" : "perfsonar.its.msstate.edu"
          },
-         "archives" : [
-            "perfsonar.its.msstate.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.ix.ui-iccn.org" : {
@@ -16540,9 +12968,6 @@
             "display-name" : "perfsonar.ix.ui-iccn.org",
             "organization-display-name" : "ICCN"
          },
-         "archives" : [
-            "perfsonar.ix.ui-iccn.org"
-         ],
          "no-agent" : true
       },
       "perfsonar.malone.edu" : {
@@ -16550,9 +12975,6 @@
             "display-name" : "perfsonar.malone.edu",
             "organization-display-name" : "perfsonar.malone.edu"
          },
-         "archives" : [
-            "perfsonar.malone.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.marcc.jhu.edu" : {
@@ -16561,9 +12983,6 @@
             "organization-display-name" : "John Hopkins University",
             "site-display-name" : "John Hopkins University"
          },
-         "archives" : [
-            "perfsonar.marcc.jhu.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.marshall.edu" : {
@@ -16571,9 +12990,6 @@
             "display-name" : "perfsonar.marshall.edu",
             "organization-display-name" : "perfsonar.marshall.edu"
          },
-         "archives" : [
-            "perfsonar.marshall.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.merit.edu" : {
@@ -16582,9 +12998,6 @@
             "organization-display-name" : "MERIT",
             "site-display-name" : "MERIT"
          },
-         "archives" : [
-            "perfsonar.merit.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.nchc.org.tw" : {
@@ -16592,9 +13005,6 @@
             "display-name" : "perfsonar.nchc.org.tw",
             "organization-display-name" : "perfsonar.nchc.org.tw"
          },
-         "archives" : [
-            "perfsonar.nchc.org.tw"
-         ],
          "no-agent" : true
       },
       "ps-lat.nersc.gov" : {
@@ -16602,9 +13012,6 @@
             "display-name" : "ps-lat.nersc.gov",
             "organization-display-name" : "NERSC"
          },
-         "archives" : [
-            "ps-lat.nersc.gov"
-         ],
          "no-agent" : true
       },
       "perfsonar.net.cmu.edu" : {
@@ -16612,9 +13019,6 @@
             "display-name" : "perfsonar.net.cmu.edu",
             "organization-display-name" : "perfsonar.net.cmu.edu"
          },
-         "archives" : [
-            "perfsonar.net.cmu.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.ns.utk.edu" : {
@@ -16622,9 +13026,6 @@
             "display-name" : "perfsonar.ns.utk.edu",
             "organization-display-name" : "University of Tennessee"
          },
-         "archives" : [
-            "perfsonar.ns.utk.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.ornl.gov" : {
@@ -16632,9 +13033,6 @@
             "display-name" : "perfsonar.ornl.gov",
             "organization-display-name" : "Oakridge National Lab"
          },
-         "archives" : [
-            "perfsonar.ornl.gov"
-         ],
          "no-agent" : true
       },
       "perfsonar.oshean.org" : {
@@ -16643,9 +13041,6 @@
             "organization-display-name" : "OSHEAN, Inc",
             "site-display-name" : "OSHEAN, Inc"
          },
-         "archives" : [
-            "perfsonar.oshean.org"
-         ],
          "no-agent" : true
       },
       "perfsonar.pregi.net" : {
@@ -16653,9 +13048,6 @@
             "display-name" : "perfsonar.pregi.net",
             "organization-display-name" : "PREGINET, Philippines"
          },
-         "archives" : [
-            "perfsonar.pregi.net"
-         ],
          "no-agent" : true
       },
       "perfsonar.sci.cwru.edu" : {
@@ -16663,9 +13055,6 @@
             "display-name" : "perfsonar.sci.cwru.edu",
             "organization-display-name" : "Case Western Reserve University"
          },
-         "archives" : [
-            "perfsonar.sci.cwru.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.si.umich.edu" : {
@@ -16673,9 +13062,6 @@
             "display-name" : "perfsonar.si.umich.edu",
             "organization-display-name" : "University of Michigan"
          },
-         "archives" : [
-            "perfsonar.si.umich.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.tamucc.edu" : {
@@ -16684,9 +13070,6 @@
             "organization-display-name" : "TAMU CC",
             "site-display-name" : "Texas A&M CC DMZ"
          },
-         "archives" : [
-            "perfsonar.tamucc.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.ucad.sn" : {
@@ -16694,9 +13077,6 @@
             "display-name" : "perfsonar.ucad.sn",
             "organization-display-name" : "perfsonar.ucad.sn"
          },
-         "archives" : [
-            "perfsonar.ucad.sn"
-         ],
          "no-agent" : true
       },
       "perfsonar.unm.edu" : {
@@ -16704,9 +13084,6 @@
             "display-name" : "perfsonar.unm.edu",
             "organization-display-name" : "University of New Mexico"
          },
-         "archives" : [
-            "perfsonar.unm.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.uog.edu" : {
@@ -16714,9 +13091,6 @@
             "display-name" : "perfsonar.uog.edu",
             "organization-display-name" : "perfsonar.uog.edu"
          },
-         "archives" : [
-            "perfsonar.uog.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar.uoregon.edu" : {
@@ -16724,9 +13098,6 @@
             "display-name" : "perfsonar.uoregon.edu",
             "organization-display-name" : "University of Oregon"
          },
-         "archives" : [
-            "perfsonar.uoregon.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar01.cmsaf.mit.edu" : {
@@ -16735,9 +13106,6 @@
             "organization-display-name" : "MIT High Performance Computing Center @ Bates LinAcc",
             "site-display-name" : "MIT High Performance Computing Center @ Bates LinAcc"
          },
-         "archives" : [
-            "perfsonar01.cmsaf.mit.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar01.ft.uam.es" : {
@@ -16745,9 +13113,6 @@
             "display-name" : "perfsonar01.ft.uam.es",
             "organization-display-name" : "UAM-LCG2, Madrid , ES"
          },
-         "archives" : [
-            "perfsonar01.ft.uam.es"
-         ],
          "no-agent" : true
       },
       "perfsonar01.ibest.uidaho.edu" : {
@@ -16755,9 +13120,6 @@
             "display-name" : "perfsonar01.ibest.uidaho.edu",
             "organization-display-name" : "University of Idaho (ibest)"
          },
-         "archives" : [
-            "perfsonar01.ibest.uidaho.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar01.its.uidaho.edu" : {
@@ -16765,9 +13127,6 @@
             "display-name" : "perfsonar01.its.uidaho.edu",
             "organization-display-name" : "University of Idaho"
          },
-         "archives" : [
-            "perfsonar01.its.uidaho.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar01.jc.rl.ac.uk" : {
@@ -16775,9 +13134,6 @@
             "display-name" : "perfsonar01.jc.rl.ac.uk",
             "organization-display-name" : "UK Centre for Environmental Data Archival"
          },
-         "archives" : [
-            "perfsonar01.jc.rl.ac.uk"
-         ],
          "no-agent" : true
       },
       "perfsonar02.cmsaf.mit.edu" : {
@@ -16786,9 +13142,6 @@
             "organization-display-name" : "MIT High Performance Computing Center @ Bates LinAcc",
             "site-display-name" : "MIT High Performance Computing Center @ Bates LinAcc"
          },
-         "archives" : [
-            "perfsonar02.cmsaf.mit.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar02.ft.uam.es" : {
@@ -16796,9 +13149,6 @@
             "display-name" : "perfsonar02.ft.uam.es",
             "organization-display-name" : "UAM-LCG2, Madrid , ES"
          },
-         "archives" : [
-            "perfsonar02.ft.uam.es"
-         ],
          "no-agent" : true
       },
       "perfsonar1-rain.rc.pdx.edu" : {
@@ -16806,9 +13156,6 @@
             "display-name" : "perfsonar1-rain.rc.pdx.edu",
             "organization-display-name" : "perfsonar1-rain.rc.pdx.edu"
          },
-         "archives" : [
-            "perfsonar1-rain.rc.pdx.edu"
-         ],
          "no-agent" : true
       },
       "128.219.141.59" : {
@@ -16816,9 +13163,6 @@
             "display-name" : "perfsonar.ccs.ornl.gov",
             "organization-display-name" : "OLCF"
          },
-         "archives" : [
-            "128.219.141.59"
-         ],
          "no-agent" : true
       },
       "perfsonar1.rc.pdx.edu" : {
@@ -16826,9 +13170,6 @@
             "display-name" : "perfsonar1.rc.pdx.edu",
             "organization-display-name" : "Portland State University"
          },
-         "archives" : [
-            "perfsonar1.rc.pdx.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar1.research-lan.colostate.edu" : {
@@ -16836,9 +13177,6 @@
             "display-name" : "perfsonar1.research-lan.colostate.edu",
             "organization-display-name" : "Colorado State University"
          },
-         "archives" : [
-            "perfsonar1.research-lan.colostate.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar1.sfasu.edu" : {
@@ -16846,9 +13184,6 @@
             "display-name" : "perfsonar1.sfasu.edu",
             "organization-display-name" : "perfsonar1.sfasu.edu"
          },
-         "archives" : [
-            "perfsonar1.sfasu.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar2-de-kit.gridka.de" : {
@@ -16856,9 +13191,6 @@
             "display-name" : "perfsonar2-de-kit.gridka.de",
             "organization-display-name" : "Karlsruhe Institute of Technology (KIT), Karlsruhe , DE"
          },
-         "archives" : [
-            "perfsonar2-de-kit.gridka.de"
-         ],
          "no-agent" : true
       },
       "perfsonar2.icepp.jp" : {
@@ -16866,9 +13198,6 @@
             "display-name" : "perfsonar2.icepp.jp",
             "organization-display-name" : "University of Tokyo In ICEPP"
          },
-         "archives" : [
-            "perfsonar2.icepp.jp"
-         ],
          "no-agent" : true
       },
       "perfsonar2.ihep.ac.cn" : {
@@ -16876,9 +13205,6 @@
             "display-name" : "perfsonar2.ihep.ac.cn",
             "organization-display-name" : "IHEP"
          },
-         "archives" : [
-            "perfsonar2.ihep.ac.cn"
-         ],
          "no-agent" : true
       },
       "perfsonar2.rc.pdx.edu" : {
@@ -16886,9 +13212,6 @@
             "display-name" : "perfsonar2.rc.pdx.edu",
             "organization-display-name" : "Portland State University"
          },
-         "archives" : [
-            "perfsonar2.rc.pdx.edu"
-         ],
          "no-agent" : true
       },
       "perfsonar4.usd.edu" : {
@@ -16896,9 +13219,6 @@
             "display-name" : "perfsonar4.usd.edu",
             "organization-display-name" : "perfsonar4.usd.edu"
          },
-         "archives" : [
-            "perfsonar4.usd.edu"
-         ],
          "no-agent" : true
       },
       "perfsonarhsc.unt.edu" : {
@@ -16906,9 +13226,6 @@
             "display-name" : "perfsonarhsc.unt.edu",
             "organization-display-name" : "perfsonarhsc.unt.edu"
          },
-         "archives" : [
-            "perfsonarhsc.unt.edu"
-         ],
          "no-agent" : true
       },
       "personar-ve.nnmc.edu" : {
@@ -16916,9 +13233,6 @@
             "display-name" : "personar-ve.nnmc.edu",
             "organization-display-name" : "Northern New Mexico College"
          },
-         "archives" : [
-            "personar-ve.nnmc.edu"
-         ],
          "no-agent" : true
       },
       "pfsnr-pu.kenet.or.ke" : {
@@ -16926,37 +13240,25 @@
             "display-name" : "pfsnr-pu.kenet.or.ke",
             "organization-display-name" : "KENET, Nairobi"
          },
-         "archives" : [
-            "pfsnr-pu.kenet.or.ke"
-         ],
          "no-agent" : true
       },
       "pnwg-pt1.es.net" : {
          "_meta" : {
             "display-name" : "pnwg-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "pnwg-pt1.es.net"
-         ]
+         }
       },
       "pppl-pt1.es.net" : {
          "_meta" : {
             "display-name" : "pppl-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "pppl-pt1.es.net"
-         ]
+         }
       },
       "ps-10g-border-asm-0.tools.ucla.net" : {
          "_meta" : {
             "display-name" : "ps-10g-border-asm-0.tools.ucla.net",
             "organization-display-name" : "ps-10g-border-asm-0.tools.ucla.net"
          },
-         "archives" : [
-            "ps-10g-border-asm-0.tools.ucla.net"
-         ],
          "no-agent" : true
       },
       "ps-10g-dmz.msu.montana.edu" : {
@@ -16964,9 +13266,6 @@
             "display-name" : "ps-10g-dmz.msu.montana.edu",
             "organization-display-name" : "ps-10g-dmz.msu.montana.edu"
          },
-         "archives" : [
-            "ps-10g-dmz.msu.montana.edu"
-         ],
          "no-agent" : true
       },
       "ps-10g.ncsa.illinois.edu" : {
@@ -16974,9 +13273,6 @@
             "display-name" : "ps-10g.ncsa.illinois.edu",
             "organization-display-name" : "National Center for Supercomputing Applications"
          },
-         "archives" : [
-            "ps-10g.ncsa.illinois.edu"
-         ],
          "no-agent" : true
       },
       "ps-2.oit.umass.edu" : {
@@ -16984,9 +13280,6 @@
             "display-name" : "ps-2.oit.umass.edu",
             "organization-display-name" : "ps-2.oit.umass.edu"
          },
-         "archives" : [
-            "ps-2.oit.umass.edu"
-         ],
          "no-agent" : true
       },
       "ps-40g-hpr01.stanford.edu" : {
@@ -16994,9 +13287,6 @@
             "display-name" : "ps-40g-hpr01.stanford.edu",
             "organization-display-name" : "Stanford University"
          },
-         "archives" : [
-            "ps-40g-hpr01.stanford.edu"
-         ],
          "no-agent" : true
       },
       "ps-arc-meter.nren.nasa.gov" : {
@@ -17004,9 +13294,6 @@
             "display-name" : "ps-arc-meter.nren.nasa.gov",
             "organization-display-name" : "NASA"
          },
-         "archives" : [
-            "ps-arc-meter.nren.nasa.gov"
-         ],
          "no-agent" : true
       },
       "ps-bandwidth.atlas.unimelb.edu.au" : {
@@ -17014,9 +13301,6 @@
             "display-name" : "ps-bandwidth.atlas.unimelb.edu.au",
             "organization-display-name" : "University of Melbourne"
          },
-         "archives" : [
-            "ps-bandwidth.atlas.unimelb.edu.au"
-         ],
          "no-agent" : true
       },
       "ps-bandwidth.hep.pnnl.gov" : {
@@ -17024,9 +13308,6 @@
             "display-name" : "ps-bandwidth.hep.pnnl.gov",
             "organization-display-name" : "PNNL Physics"
          },
-         "archives" : [
-            "ps-bandwidth.hep.pnnl.gov"
-         ],
          "no-agent" : true
       },
       "ps-bandwidth.hepnetcanada.ca" : {
@@ -17035,9 +13316,6 @@
             "organization-display-name" : "University of Victoria, Canada",
             "site-display-name" : "University of Victoria, Canada"
          },
-         "archives" : [
-            "ps-bandwidth.hepnetcanada.ca"
-         ],
          "no-agent" : true
       },
       "ps-border1-bwctl.lbl.gov" : {
@@ -17045,9 +13323,6 @@
             "display-name" : "ps-border1-bwctl.lbl.gov",
             "organization-display-name" : "Lawrence Berkeley National Lab"
          },
-         "archives" : [
-            "ps-border1-bwctl.lbl.gov"
-         ],
          "no-agent" : true
       },
       "ps-border1-owamp.lbl.gov" : {
@@ -17055,9 +13330,6 @@
             "display-name" : "ps-border1-owamp.lbl.gov",
             "organization-display-name" : "Lawrence Berkeley National Lab"
          },
-         "archives" : [
-            "ps-border1-owamp.lbl.gov"
-         ],
          "no-agent" : true
       },
       "ps-bw.ln.net" : {
@@ -17065,9 +13337,6 @@
             "display-name" : "ps-bw.ln.net",
             "organization-display-name" : "Los Nettos"
          },
-         "archives" : [
-            "ps-bw.ln.net"
-         ],
          "no-agent" : true
       },
       "ps-bw.sdmz.rnp.br" : {
@@ -17076,9 +13345,6 @@
             "organization-display-name" : "RNP Brazil",
             "site-display-name" : "RNP Brazil (Rio de Janeiro)"
          },
-         "archives" : [
-            "ps-bw.sdmz.rnp.br"
-         ],
          "no-agent" : true
       },
       "ps-datacenter.netserv.wayne.edu" : {
@@ -17086,9 +13352,6 @@
             "display-name" : "ps-datacenter.netserv.wayne.edu",
             "organization-display-name" : "ps-datacenter.netserv.wayne.edu"
          },
-         "archives" : [
-            "ps-datacenter.netserv.wayne.edu"
-         ],
          "no-agent" : true
       },
       "ps-delay.pnw-gigapop.net" : {
@@ -17096,9 +13359,6 @@
             "display-name" : "ps-delay.pnw-gigapop.net",
             "organization-display-name" : "PNWGP"
          },
-         "archives" : [
-            "ps-delay.pnw-gigapop.net"
-         ],
          "no-agent" : true
       },
       "ps-dmz-1.unm.edu" : {
@@ -17106,9 +13366,6 @@
             "display-name" : "ps-dmz-1.unm.edu",
             "organization-display-name" : "University of New Mexico"
          },
-         "archives" : [
-            "ps-dmz-1.unm.edu"
-         ],
          "no-agent" : true
       },
       "ps-grand-bw.kanren.net" : {
@@ -17116,9 +13373,6 @@
             "display-name" : "ps-grand-bw.kanren.net",
             "organization-display-name" : "KanRen"
          },
-         "archives" : [
-            "ps-grand-bw.kanren.net"
-         ],
          "no-agent" : true
       },
       "ps-grand-lt.kanren.net" : {
@@ -17126,9 +13380,6 @@
             "display-name" : "ps-grand-lt.kanren.net",
             "organization-display-name" : "KanRen"
          },
-         "archives" : [
-            "ps-grand-lt.kanren.net"
-         ],
          "no-agent" : true
       },
       "ps-ksu-bw.kanren.net" : {
@@ -17136,9 +13387,6 @@
             "display-name" : "ps-ksu-bw.kanren.net",
             "organization-display-name" : "KanRen"
          },
-         "archives" : [
-            "ps-ksu-bw.kanren.net"
-         ],
          "no-agent" : true
       },
       "ps-ksu-lt.kanren.net" : {
@@ -17146,9 +13394,6 @@
             "display-name" : "ps-ksu-lt.kanren.net",
             "organization-display-name" : "KanRen"
          },
-         "archives" : [
-            "ps-ksu-lt.kanren.net"
-         ],
          "no-agent" : true
       },
       "ps-latency.atlas.unimelb.edu.au" : {
@@ -17156,9 +13401,6 @@
             "display-name" : "ps-latency.atlas.unimelb.edu.au",
             "organization-display-name" : "University of Melbourne"
          },
-         "archives" : [
-            "ps-latency.atlas.unimelb.edu.au"
-         ],
          "no-agent" : true
       },
       "ps-latency.hepnetcanada.ca" : {
@@ -17167,9 +13409,6 @@
             "organization-display-name" : "University of Victoria, Canada",
             "site-display-name" : "University of Victoria, Canada"
          },
-         "archives" : [
-            "ps-latency.hepnetcanada.ca"
-         ],
          "no-agent" : true
       },
       "ps-lax-10g.cenic.net" : {
@@ -17177,9 +13416,6 @@
             "display-name" : "ps-lax-10g.cenic.net",
             "organization-display-name" : "CENIC LAX"
          },
-         "archives" : [
-            "ps-lax-10g.cenic.net"
-         ],
          "no-agent" : true
       },
       "ps-lax-owamp.cenic.net" : {
@@ -17187,9 +13423,6 @@
             "display-name" : "ps-lax-owamp.cenic.net",
             "organization-display-name" : "CENIC LAX"
          },
-         "archives" : [
-            "ps-lax-dc-owamp.cenic.net"
-         ],
          "no-agent" : true
       },
       "ps-slough-1g.ja.net" : {
@@ -17214,9 +13447,6 @@
             "organization-display-name" : "PacificWave",
             "site-display-name" : "PacificWave Los Angeles"
          },
-         "archives" : [
-            "207.231.241.157"
-         ],
          "no-agent" : true
       },
       "ps-lt.ampath.ampath.net" : {
@@ -17224,9 +13454,6 @@
             "display-name" : "ps-lt.ampath.ampath.net",
             "organization-display-name" : "AMPATH"
          },
-         "archives" : [
-            "ps-lt.ampath.ampath.net"
-         ],
          "no-agent" : true
       },
       "ps-lt.sdmz.rnp.br" : {
@@ -17235,9 +13462,6 @@
             "organization-display-name" : "RNP Brazil",
             "site-display-name" : "RNP Brazil (Rio de Janeiro)"
          },
-         "archives" : [
-            "ps-lt.sdmz.rnp.br"
-         ],
          "no-agent" : true
       },
       "ps-rtr-106-22.jpl.nasa.gov" : {
@@ -17245,9 +13469,6 @@
             "display-name" : "ps-rtr-106-22.jpl.nasa.gov",
             "organization-display-name" : "JPL"
          },
-         "archives" : [
-            "137.78.106.22"
-         ],
          "no-agent" : true
       },
       "ps-sd.rc.uab.edu" : {
@@ -17255,9 +13476,6 @@
             "display-name" : "ps-sd.rc.uab.edu",
             "organization-display-name" : "ps-sd.rc.uab.edu"
          },
-         "archives" : [
-            "ps-sd.rc.uab.edu"
-         ],
          "no-agent" : true
       },
       "ps-sttl-10g02.pacificwave.net" : {
@@ -17266,9 +13484,6 @@
             "organization-display-name" : "PacificWave",
             "site-display-name" : "PacificWave Seattle"
          },
-         "archives" : [
-            "207.231.241.25"
-         ],
          "no-agent" : true
       },
       "ps-svl-10g.cenic.net" : {
@@ -17276,9 +13491,6 @@
             "display-name" : "ps-svl-10g.cenic.net",
             "organization-display-name" : "CENIC SVL"
          },
-         "archives" : [
-            "ps-svl-10g.cenic.net"
-         ],
          "no-agent" : true
       },
       "ps-svl-owamp.cenic.net" : {
@@ -17286,9 +13498,6 @@
             "display-name" : "ps-svl-owamp.cenic.net",
             "organization-display-name" : "CENIC SVL"
          },
-         "archives" : [
-            "ps-svl-owamp.cenic.net"
-         ],
          "no-agent" : true
       },
       "ps-uva.dynes.virginia.edu" : {
@@ -17296,9 +13505,6 @@
             "display-name" : "ps-uva.dynes.virginia.edu",
             "organization-display-name" : "ps-uva.dynes.virginia.edu"
          },
-         "archives" : [
-            "ps-uva.dynes.virginia.edu"
-         ],
          "no-agent" : true
       },
       "ps.3rox.net" : {
@@ -17307,9 +13513,6 @@
             "organization-display-name" : "Three Rivers Optical Exchange (3ROX)",
             "site-display-name" : "Three Rivers Optical Exchange (3ROX)"
          },
-         "archives" : [
-            "ps.3rox.net"
-         ],
          "no-agent" : true
       },
       "ps.daej.kreonet2.net" : {
@@ -17317,9 +13520,6 @@
             "display-name" : "ps.daej.kreonet2.net",
             "organization-display-name" : "KREONET"
          },
-         "archives" : [
-            "ps.daej.kreonet2.net"
-         ],
          "no-agent" : true
       },
       "ps.daejeon.nfri.re.kr" : {
@@ -17328,9 +13528,6 @@
             "organization-display-name" : "NFRI",
             "site-display-name" : "NFRI"
          },
-         "archives" : [
-            "ps.daejeon.nfri.re.kr"
-         ],
          "no-agent" : true
       },
       "ps.iu.xsede.org" : {
@@ -17339,9 +13536,6 @@
             "organization-display-name" : "XSEDE",
             "site-display-name" : "Indiana University"
          },
-         "archives" : [
-            "ps.iu.xsede.org"
-         ],
          "no-agent" : true
       },
       "ps.ncar.xsede.org" : {
@@ -17350,9 +13544,6 @@
             "organization-display-name" : "XSEDE",
             "site-display-name" : "National Center for Atmospheric Research"
          },
-         "archives" : [
-            "ps.ncar.xsede.org"
-         ],
          "no-agent" : true
       },
       "ps.ncp.edu.pk" : {
@@ -17360,9 +13551,6 @@
             "display-name" : "ps.ncp.edu.pk",
             "organization-display-name" : "ps.ncp.edu.pk"
          },
-         "archives" : [
-            "ps.ncp.edu.pk"
-         ],
          "no-agent" : true
       },
       "ps.ncsa.xsede.org" : {
@@ -17371,9 +13559,6 @@
             "organization-display-name" : "XSEDE",
             "site-display-name" : "NCSA"
          },
-         "archives" : [
-            "ps.ncsa.xsede.org"
-         ],
          "no-agent" : true
       },
       "ps.nics.utk.edu" : {
@@ -17381,9 +13566,6 @@
             "display-name" : "ps.nics.utk.edu",
             "organization-display-name" : "University of Tennessee - Knoxville"
          },
-         "archives" : [
-            "ps.nics.utk.edu"
-         ],
          "no-agent" : true
       },
       "ps.psc.xsede.org" : {
@@ -17392,9 +13574,6 @@
             "organization-display-name" : "XSEDE",
             "site-display-name" : "Pittsburgh Supercomputing Center"
          },
-         "archives" : [
-            "ps.psc.xsede.org"
-         ],
          "no-agent" : true
       },
       "ps.sdsc.xsede.org" : {
@@ -17403,9 +13582,6 @@
             "organization-display-name" : "XSEDE",
             "site-display-name" : "San Diego Supercomputer Center (SDSC)"
          },
-         "archives" : [
-            "ps.sdsc.xsede.org"
-         ],
          "no-agent" : true
       },
       "ps.tacc.xsede.org" : {
@@ -17414,9 +13590,6 @@
             "organization-display-name" : "XSEDE",
             "site-display-name" : "Texas Advanced Computing Center"
          },
-         "archives" : [
-            "ps.tacc.xsede.org"
-         ],
          "no-agent" : true
       },
       "ps.test.manlan.internet2.edu" : {
@@ -17424,9 +13597,6 @@
             "display-name" : "ps.test.manlan.internet2.edu",
             "organization-display-name" : "MANLAN"
          },
-         "archives" : [
-            "ps.test.manlan.internet2.edu"
-         ],
          "no-agent" : true
       },
       "ps.test.wix.internet2.edu" : {
@@ -17434,9 +13604,6 @@
             "display-name" : "ps.test.wix.internet2.edu",
             "organization-display-name" : "WIX"
          },
-         "archives" : [
-            "ps.test.wix.internet2.edu"
-         ],
          "no-agent" : true
       },
       "ps1-100g-sdmz.chat.tmc.edu" : {
@@ -17444,9 +13611,6 @@
             "display-name" : "ps1-100g-sdmz.chat.tmc.edu",
             "organization-display-name" : "ps1-100g-sdmz.chat.tmc.edu"
          },
-         "archives" : [
-            "ps1-100g-sdmz.chat.tmc.edu"
-         ],
          "no-agent" : true
       },
       "ps1-akard-dlls.tx-learn.net" : {
@@ -17455,9 +13619,6 @@
             "organization-display-name" : "LEARN Dallas",
             "site-display-name" : "LEARN Dallas"
          },
-         "archives" : [
-            "ps1-akard-dlls.tx-learn.net"
-         ],
          "no-agent" : true
       },
       "ps1-hardy-hstn.tx-learn.net" : {
@@ -17466,9 +13627,6 @@
             "organization-display-name" : "LEARN Houston",
             "site-display-name" : "LEARN Houston"
          },
-         "archives" : [
-            "ps1-hardy-hstn.tx-learn.net"
-         ],
          "no-agent" : true
       },
       "ps1.daej.kreonet2.net" : {
@@ -17476,9 +13634,6 @@
             "display-name" : "ps1.daej.kreonet2.net",
             "organization-display-name" : "KREONET"
          },
-         "archives" : [
-            "ps1.daej.kreonet2.net"
-         ],
          "no-agent" : true
       },
       "ps1.netherlight.net" : {
@@ -17486,9 +13641,6 @@
             "display-name" : "ps1.netherlight.net",
             "organization-display-name" : "Netherlight Amsterdam"
          },
-         "archives" : [
-            "ps1.netherlight.net"
-         ],
          "no-agent" : true
       },
       "ps1.renci.org" : {
@@ -17497,9 +13649,6 @@
             "organization-display-name" : "RENCI",
             "site-display-name" : "RENCI"
          },
-         "archives" : [
-            "ps1.renci.org"
-         ],
          "no-agent" : true
       },
       "ps2.netherlight.net" : {
@@ -17507,9 +13656,6 @@
             "display-name" : "ps2.netherlight.net",
             "organization-display-name" : "Netherlight Amsterdam"
          },
-         "archives" : [
-            "ps2.netherlight.net"
-         ],
          "no-agent" : true
       },
       "ps3.crc.rice.edu" : {
@@ -17518,9 +13664,6 @@
             "organization-display-name" : "Rice University",
             "site-display-name" : "Rice University Research Computing"
          },
-         "archives" : [
-            "ps3.crc.rice.edu"
-         ],
          "no-agent" : true
       },
       "psb-bw.ncsa.illinois.edu" : {
@@ -17528,9 +13671,6 @@
             "display-name" : "psb-bw.ncsa.illinois.edu",
             "organization-display-name" : "National Center for Supercomputing Applications (NCSA) Blue Waters"
          },
-         "archives" : [
-            "psb-bw.ncsa.illinois.edu"
-         ],
          "no-agent" : true
       },
       "psl-bw.ncsa.illinois.edu" : {
@@ -17538,9 +13678,6 @@
             "display-name" : "psl-bw.ncsa.illinois.edu",
             "organization-display-name" : "National Center for Supercomputing Applications (NCSA) Blue Waters"
          },
-         "archives" : [
-            "psl-bw.ncsa.illinois.edu"
-         ],
          "no-agent" : true
       },
       "psmsu01.aglt2.org" : {
@@ -17548,9 +13685,6 @@
             "display-name" : "psmsu01.aglt2.org",
             "organization-display-name" : "Michigan State University"
          },
-         "archives" : [
-            "psmsu01.aglt2.org"
-         ],
          "no-agent" : true
       },
       "psmsu02.aglt2.org" : {
@@ -17558,9 +13692,6 @@
             "display-name" : "psmsu02.aglt2.org",
             "organization-display-name" : "Michigan State University"
          },
-         "archives" : [
-            "psmsu02.aglt2.org"
-         ],
          "no-agent" : true
       },
       "psnr-farm10.slac.stanford.edu" : {
@@ -17568,9 +13699,6 @@
             "display-name" : "psnr-farm10.slac.stanford.edu",
             "organization-display-name" : "SLAC"
          },
-         "archives" : [
-            "psnr-farm10.slac.stanford.edu"
-         ],
          "no-agent" : true
       },
       "psonar-core.gw.utexas.edu" : {
@@ -17578,9 +13706,6 @@
             "display-name" : "psonar-core.gw.utexas.edu",
             "organization-display-name" : "psonar-core.gw.utexas.edu"
          },
-         "archives" : [
-            "psonar-core.gw.utexas.edu"
-         ],
          "no-agent" : true
       },
       "psonar.arc.vt.edu" : {
@@ -17588,9 +13713,6 @@
             "display-name" : "psonar.arc.vt.edu",
             "organization-display-name" : "psonar.arc.vt.edu"
          },
-         "archives" : [
-            "psonar.arc.vt.edu"
-         ],
          "no-agent" : true
       },
       "psonar5.deemz.net_FNAL" : {
@@ -17599,9 +13721,6 @@
             "organization-display-name" : "Fermi National Lab",
             "site-display-name" : "Fermi National Lab"
          },
-         "archives" : [
-            "psonar5.deemz.net"
-         ],
          "no-agent" : true
       },
       "psum01.aglt2.org" : {
@@ -17609,9 +13728,6 @@
             "display-name" : "psum01.aglt2.org",
             "organization-display-name" : "University of Michigan"
          },
-         "archives" : [
-            "psum01.aglt2.org"
-         ],
          "no-agent" : true
       },
       "psum02.aglt2.org" : {
@@ -17619,9 +13735,6 @@
             "display-name" : "psum02.aglt2.org",
             "organization-display-name" : "University of Michigan"
          },
-         "archives" : [
-            "psum02.aglt2.org"
-         ],
          "no-agent" : true
       },
       "psvm.nrel.gov" : {
@@ -17629,9 +13742,6 @@
             "display-name" : "psvm.nrel.gov",
             "organization-display-name" : "NREL"
          },
-         "archives" : [
-            "psvm.nrel.gov"
-         ],
          "no-agent" : true
       },
       "rneonly-ps.ps.uhnet.net" : {
@@ -17639,9 +13749,6 @@
             "display-name" : "rneonly-ps.ps.uhnet.net",
             "organization-display-name" : "University Of Hawaii In Honolulu , HI , US"
          },
-         "archives" : [
-            "rneonly-ps.ps.uhnet.net"
-         ],
          "no-agent" : true
       },
       "sampaps01.if.usp.br" : {
@@ -17649,9 +13756,6 @@
             "display-name" : "sampaps01.if.usp.br",
             "organization-display-name" : "University of SÃÂ£o Paulo"
          },
-         "archives" : [
-            "sampaps01.if.usp.br"
-         ],
          "no-agent" : true
       },
       "sampaps02.if.usp.br" : {
@@ -17659,9 +13763,6 @@
             "display-name" : "sampaps02.if.usp.br",
             "organization-display-name" : "University of SÃÂ£o Paulo"
          },
-         "archives" : [
-            "sampaps02.if.usp.br"
-         ],
          "no-agent" : true
       },
       "scidmz-ps1.scidmz.uchicago.net" : {
@@ -17669,9 +13770,6 @@
             "display-name" : "scidmz-ps1.scidmz.uchicago.net",
             "organization-display-name" : "University of Chicago"
          },
-         "archives" : [
-            "scidmz-ps1.scidmz.uchicago.net"
-         ],
          "no-agent" : true
       },
       "scidmz-ps12.scidmz.uchicago.net" : {
@@ -17679,9 +13777,6 @@
             "display-name" : "scidmz-ps12.scidmz.uchicago.net",
             "organization-display-name" : "scidmz-ps12.scidmz.uchicago.net"
          },
-         "archives" : [
-            "scidmz-ps12.scidmz.uchicago.net"
-         ],
          "no-agent" : true
       },
       "scidmz-tp.ps.uhnet.net" : {
@@ -17689,9 +13784,6 @@
             "display-name" : "scidmz-tp.ps.uhnet.net",
             "organization-display-name" : "University Of Hawaii In Honolulu , HI , US"
          },
-         "archives" : [
-            "scidmz-tp.ps.uhnet.net"
-         ],
          "no-agent" : true
       },
       "sdm01.rcc.uchicago.edu" : {
@@ -17699,28 +13791,19 @@
             "display-name" : "sdm01.rcc.uchicago.edu",
             "organization-display-name" : "University of Chicago"
          },
-         "archives" : [
-            "sdm01.rcc.uchicago.edu"
-         ],
          "no-agent" : true
       },
       "snll-pt1.es.net" : {
          "_meta" : {
             "display-name" : "snll-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "snll-pt1.es.net"
-         ]
+         }
       },
       "sonar-west.net.yale.edu" : {
          "_meta" : {
             "display-name" : "sonar-west.net.yale.edu",
             "organization-display-name" : "sonar-west.net.yale.edu"
          },
-         "archives" : [
-            "sonar-west.net.yale.edu"
-         ],
          "no-agent" : true
       },
       "spacesonar.mit.edu" : {
@@ -17728,9 +13811,6 @@
             "display-name" : "spacesonar.mit.edu",
             "organization-display-name" : "spacesonar.mit.edu"
          },
-         "archives" : [
-            "spacesonar.mit.edu"
-         ],
          "no-agent" : true
       },
       "speedtest1.net.siue.edu" : {
@@ -17738,9 +13818,6 @@
             "display-name" : "speedtest1.net.siue.edu",
             "organization-display-name" : "speedtest1.net.siue.edu"
          },
-         "archives" : [
-            "speedtest1.net.siue.edu"
-         ],
          "no-agent" : true
       },
       "speedtest2.pnl.gov" : {
@@ -17748,9 +13825,6 @@
             "display-name" : "speedtest2.pnl.gov",
             "organization-display-name" : "PNNL"
          },
-         "archives" : [
-            "speedtest2.pnl.gov"
-         ],
          "no-agent" : true
       },
       "speedy.greatplains.net" : {
@@ -17759,9 +13833,6 @@
             "organization-display-name" : "Great Plains Network (GPN)",
             "site-display-name" : "Great Plains Network (GPN)"
          },
-         "archives" : [
-            "speedy.greatplains.net"
-         ],
          "no-agent" : true
       },
       "srcf-ps.stanford.edu" : {
@@ -17769,37 +13840,25 @@
             "display-name" : "srcf-ps.stanford.edu",
             "organization-display-name" : "Stanford"
          },
-         "archives" : [
-            "srcf-ps.stanford.edu"
-         ],
          "no-agent" : true
       },
       "sunn-pt1.es.net" : {
          "_meta" : {
             "display-name" : "sunn-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "sunn-pt1.es.net"
-         ]
+         }
       },
       "test-pt1.es.net" : {
          "_meta" : {
             "display-name" : "test-pt1.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "198.129.252.42"
-         ]
+         }
       },
       "test10g.lsi.umich.edu" : {
          "_meta" : {
             "display-name" : "test10g.lsi.umich.edu",
             "organization-display-name" : "University of Michigan"
          },
-         "archives" : [
-            "test10g.lsi.umich.edu"
-         ],
          "no-agent" : true
       },
       "tonic.crest.iu.edu" : {
@@ -17807,9 +13866,6 @@
             "display-name" : "tonic.crest.iu.edu",
             "organization-display-name" : "tonic.crest.iu.edu"
          },
-         "archives" : [
-            "tonic.crest.iu.edu"
-         ],
          "no-agent" : true
       },
       "tsunami.pub.alcf.anl.gov" : {
@@ -17817,9 +13873,6 @@
             "display-name" : "tsunami.pub.alcf.anl.gov",
             "organization-display-name" : "Argonne Leadership Computing Facility"
          },
-         "archives" : [
-            "tsunami.pub.alcf.anl.gov"
-         ],
          "no-agent" : true
       },
       "tul-ps.onenet.net" : {
@@ -17828,9 +13881,6 @@
             "organization-display-name" : "OneNet",
             "site-display-name" : "OneNet"
          },
-         "archives" : [
-            "tul-ps.onenet.net"
-         ],
          "no-agent" : true
       },
       "uct2-net1.mwt2.org" : {
@@ -17838,9 +13888,6 @@
             "display-name" : "uct2-net1.mwt2.org",
             "organization-display-name" : "University of Chicago"
          },
-         "archives" : [
-            "uct2-net1.mwt2.org"
-         ],
          "no-agent" : true
       },
       "uct2-net2.mwt2.org" : {
@@ -17848,9 +13895,6 @@
             "display-name" : "uct2-net2.mwt2.org",
             "organization-display-name" : "University of Chicago"
          },
-         "archives" : [
-            "uct2-net2.mwt2.org"
-         ],
          "no-agent" : true
       },
       "uhmanoa-dl.ps.uhnet.net" : {
@@ -17858,9 +13902,6 @@
             "display-name" : "uhmanoa-dl.ps.uhnet.net",
             "organization-display-name" : "University Of Hawaii In Honolulu , HI , US"
          },
-         "archives" : [
-            "uhmanoa-dl.ps.uhnet.net"
-         ],
          "no-agent" : true
       },
       "uhmanoa-tp.ps.uhnet.net" : {
@@ -17868,9 +13909,6 @@
             "display-name" : "uhmanoa-tp.ps.uhnet.net",
             "organization-display-name" : "University Of Hawaii In Honolulu , HI , US"
          },
-         "archives" : [
-            "uhmanoa-tp.ps.uhnet.net"
-         ],
          "no-agent" : true
       },
       "uofu-ddc-dmz-bandwidth.chpc.utah.edu" : {
@@ -17878,9 +13916,6 @@
             "display-name" : "uofu-ddc-dmz-bandwidth.chpc.utah.edu",
             "organization-display-name" : "The University of Utah"
          },
-         "archives" : [
-            "uofu-ddc-dmz-bandwidth.chpc.utah.edu"
-         ],
          "no-agent" : true
       },
       "uofu-ddc-dmz-latency.chpc.utah.edu" : {
@@ -17888,9 +13923,6 @@
             "display-name" : "uofu-ddc-dmz-latency.chpc.utah.edu",
             "organization-display-name" : "The University of Utah"
          },
-         "archives" : [
-            "uofu-ddc-dmz-latency.chpc.utah.edu"
-         ],
          "no-agent" : true
       },
       "uofu-science-dmz-bandwidth.chpc.utah.edu" : {
@@ -17898,9 +13930,6 @@
             "display-name" : "uofu-science-dmz-bandwidth.chpc.utah.edu",
             "organization-display-name" : "The University of Utah"
          },
-         "archives" : [
-            "uofu-science-dmz-bandwidth.chpc.utah.edu"
-         ],
          "no-agent" : true
       },
       "uofu-science-dmz-latency.chpc.utah.edu" : {
@@ -17908,9 +13937,6 @@
             "display-name" : "uofu-science-dmz-latency.chpc.utah.edu",
             "organization-display-name" : "The University of Utah"
          },
-         "archives" : [
-            "uofu-science-dmz-latency.chpc.utah.edu"
-         ],
          "no-agent" : true
       },
       "vu-perf2.it.vanderbilt.edu" : {
@@ -17918,28 +13944,19 @@
             "display-name" : "vu-perf2.it.vanderbilt.edu",
             "organization-display-name" : "Vanderbilt University"
          },
-         "archives" : [
-            "vu-perf2.it.vanderbilt.edu"
-         ],
          "no-agent" : true
       },
         "wash-ps-tp.es.net" : {
          "_meta" : {
             "display-name" : "wash-ps-tp.es.net",
             "organization-display-name" : "ESnet"
-         },
-         "archives" : [
-            "wash-ps.es.net"
-         ]
+         }
       },
       "web100.pnw-gigapop.net" : {
          "_meta" : {
             "display-name" : "web100.pnw-gigapop.net",
             "organization-display-name" : "PNWGP"
          },
-         "archives" : [
-            "web100.pnw-gigapop.net"
-         ],
          "no-agent" : true
       },
       "wuit-s-00045.wustl.edu" : {
@@ -17947,9 +13964,6 @@
             "display-name" : "wuit-s-00045.wustl.edu",
             "organization-display-name" : "wuit-s-00045.wustl.edu"
          },
-         "archives" : [
-            "wuit-s-00045.wustl.edu"
-         ],
          "no-agent" : true
       },
       "132.170.30.38" : {
@@ -17957,9 +13971,6 @@
             "display-name" : "UCF-P3-132-170-30-38",
             "organization-display-name" : "UCF"
          },
-         "archives" : [
-            "132.170.30.38"
-         ],
          "no-agent" : true
       }
    },
@@ -17993,6 +14004,7 @@
              },
              "group" : "ESnet6_TP_TUNING",
              "schedule" : "schedule_0",
+             "archives": [ "ps-east" ],
              "test" : "ESnet6_TP_1_v4",
              "tools" : [
                 "iperf3"
@@ -18010,6 +14022,7 @@
              },
              "group" : "ESnet6_TP_TUNING",
              "schedule" : "schedule_0",
+             "archives": [ "ps-east" ],
              "test" : "ESnet6_TP_1_v4",
              "tools" : [
                 "iperf2"
@@ -18027,6 +14040,7 @@
         },
         "group" : "group_ESnet6_HUB_to_HUB_TP_Mesh",
         "schedule" : "schedule_0",
+        "archives": [ "ps-east" ],
         "test" : "ESnet6_TP_1_v4",
         "tools" : [
            "bwctliperf3",
@@ -18045,6 +14059,7 @@
       },
       "group" : "group_ESnet6_HUB_to_HUB_TP_Mesh",
       "schedule" : "schedule_0",
+      "archives": [ "ps-east" ],
       "test" : "ESnet6_TP_1_v6",
       "tools" : [
          "bwctliperf3",
@@ -18062,6 +14077,7 @@
            "display-task-group": ["10: ESnet to ESnet Packet Loss"]
         },
         "group" : "group_ESnet6_Path_Loss_Path_Mesh",
+        "archives": [ "ps-east" ],
         "test" : "ESnet6_LAT_1_v4"
      },
      "ESnet6_Packet_Loss_IPv6_Path_Testing" : {
@@ -18075,6 +14091,7 @@
          "display-task-group": ["99: ESnet6 Testing"]
       },
       "group" : "group_ESnet6_Path_Loss_Path_Mesh",
+      "archives": [ "ps-east" ],
       "test" : "ESnet6_LAT_1_v6"
    },
      "ESnet_to_ESnet_v4_Packet_Loss_Testing" : {
@@ -18088,6 +14105,7 @@
            "display-task-group": ["99: ESnet6 Testing"]
         },
         "group" : "ESnet6_LAT_HUB",
+        "archives": [ "ps-east" ],
         "test" : "ESnet6_LAT_1_v4"
      },
      "ESnet_to_ESnet_v6_Packet_Loss_Testing" : {
@@ -18101,6 +14119,7 @@
            "display-task-group": ["99: ESnet6 Testing"]
         },
         "group" : "ESnet6_LAT_HUB",
+        "archives": [ "ps-east" ],
         "test" : "ESnet6_LAT_1_v6"
      },
      "100G_ESnet6_Hub_to_100G_ESnet6_Hub_IPv4_Throughput_Testing" : {
@@ -18115,6 +14134,7 @@
         },
         "group" : "ESnet6_TP_HUB",
         "schedule" : "schedule_0",
+        "archives": [ "ps-east" ],
         "test" : "ESnet6_TP_1_v4",
         "tools" : [
            "bwctliperf3",
@@ -18133,6 +14153,7 @@
         },
         "group" : "ESnet6_TP_HUB",
         "schedule" : "schedule_0",
+        "archives": [ "ps-east" ],
         "test" : "ESnet6_TP_1_v6",
         "tools" : [
            "bwctliperf3",
@@ -18151,6 +14172,7 @@
         },
         "group" : "ESnet6_TP_HUB",
         "schedule" : "schedule_1",
+        "archives": [ "ps-east" ],
         "test" : "ESnet6_v4_trace"
      },
      "ESnet6_Hub_to_ESnet6_Hub_v6_Traceroute_Testing" : {
@@ -18165,6 +14187,7 @@
         },
         "group" : "ESnet6_TP_HUB",
         "schedule" : "schedule_1",
+        "archives": [ "ps-east" ],
         "test" : "ESnet6_v6_trace"
      },
      "ESnet6_v4_DNS_Testing" : {
@@ -18179,6 +14202,7 @@
       },
       "group" : "ESnet6_IPv4_DNS",
       "schedule" : "schedule_1",
+      "archives": [ "ps-east" ],
       "test" : "ESnet6_v4_DNS"
    },
       "100G_ESnet_Hub_to_100G_ESnet_Hub_IPv6_Throughput_Testing" : {
@@ -18193,6 +14217,7 @@
          },
          "group" : "group_2",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v6",
          "tools" : [
             "bwctliperf3",
@@ -18211,6 +14236,7 @@
          },
          "group" : "group_2",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18228,6 +14254,7 @@
          },
          "group" : "group_30",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18245,6 +14272,7 @@
          },
          "group" : "group_31",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18262,6 +14290,7 @@
          },
          "group" : "group_1",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18279,6 +14308,7 @@
          },
          "group" : "group_1",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_Hub_to_ESnet_Hub_Traceroute_Testing" : {
@@ -18292,6 +14322,7 @@
          },
          "group" : "group_2",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_Hub_to_DOE_Site_Border_IPv6_Throughput_Testing" : {
@@ -18306,6 +14337,7 @@
          },
          "group" : "group_0",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v6",
          "tools" : [
             "bwctliperf3",
@@ -18324,6 +14356,7 @@
          },
          "group" : "group_0",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18341,6 +14374,7 @@
          },
          "group" : "group_0",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_Hub_to_Small_DOE_Site_Border_Packet_Loss_Testing" : {
@@ -18353,6 +14387,7 @@
             "display-task-name": "{% jq .task._meta.\"display-name\" %}"
          },
          "group" : "group_9",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_Hub_to_Small_DOE_Site_Border_Throughput_Testing" : {
@@ -18366,6 +14401,7 @@
          },
          "group" : "group_3",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18383,6 +14419,7 @@
          },
          "group" : "group_9",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_Iperf3_Traceroute_Testing" : {
@@ -18396,6 +14433,7 @@
          },
          "group" : "group_32",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_Traceroute_Measurements" : {
@@ -18409,6 +14447,7 @@
          },
          "group" : "group_4",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_to_ANL_Pilot_Packet_Loss_Testing" : {
@@ -18421,6 +14460,7 @@
             "display-task-name": "{% jq .task._meta.\"display-name\" %}"
          },
          "group" : "group_15",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_to_ANL_Pilot_Throughput_Testing" : {
@@ -18434,6 +14474,7 @@
          },
          "group" : "group_14",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18451,6 +14492,7 @@
          },
          "group" : "group_14",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_to_DOE_Site_IPv6_Packet_Loss_Testing" : {
@@ -18464,6 +14506,7 @@
             "display-task-group": ["10: ESnet to ESnet Packet Loss", "30: ESnet to DOE Sites"]
          },
          "group" : "group_17",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v6"
       },
       "ESnet_to_DOE_Site_IPv4_Packet_Loss_Testing" : {
@@ -18477,6 +14520,7 @@
             "display-task-group": ["10: ESnet to ESnet Packet Loss", "30: ESnet to DOE Sites"]
          },
          "group" : "group_17",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_to_DOE_Site_IPv6_Throughput_Testing" : {
@@ -18491,6 +14535,7 @@
          },
          "group" : "group_16",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v6",
          "tools" : [
             "bwctliperf3",
@@ -18509,6 +14554,7 @@
          },
          "group" : "group_16",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18526,6 +14572,7 @@
          },
          "group" : "group_16",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_to_ESnet_European_Packet_Loss_Testing" : {
@@ -18538,6 +14585,7 @@
             "display-task-name": "{% jq .task._meta.\"display-name\" %}"
          },
          "group" : "group_8",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_to_ESnet_European_Throughput_Testing" : {
@@ -18551,6 +14599,7 @@
          },
          "group" : "group_7",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18568,6 +14617,7 @@
          },
          "group" : "group_8",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_to_ESnet_Intercontinental_Packet_Loss_Testing" : {
@@ -18580,6 +14630,7 @@
             "display-task-name": "{% jq .task._meta.\"display-name\" %}"
          },
          "group" : "group_6",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_to_ESnet_Intercontinental_Throughput_Testing" : {
@@ -18593,6 +14644,7 @@
          },
          "group" : "group_5",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18610,6 +14662,7 @@
          },
          "group" : "group_6",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_to_ESnet_IPv4_Packet_Loss_Testing" : {
@@ -18623,6 +14676,7 @@
             "display-task-group": ["10: ESnet to ESnet Packet Loss"]
          },
          "group" : "group_4",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_to_ESnet_Packet_Loss_Testing_IPv6" : {
@@ -18636,6 +14690,7 @@
             "display-task-group": ["10: ESnet to ESnet Packet Loss"]
          },
          "group" : "group_4",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v6"
       },
       "ESnet_to_ESnet_Packet_Loss_Testing_on_Throughput_Interfaces" : {
@@ -18649,6 +14704,7 @@
             "display-task-group": ["10: ESnet to ESnet Packet Loss"]
          },
          "group" : "group_4_tp",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_to_GA-EAST_IPv4_Packet_Loss_Testing" : {
@@ -18662,6 +14718,7 @@
             "display-task-group": ["80: ESnet to GA-EAST"]
          },
          "group" : "group_29",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_to_GA-EAST_IPv4_Throughput_Testing" : {
@@ -18676,6 +14733,7 @@
          },
          "group" : "group_28",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18693,6 +14751,7 @@
             "display-task-group": ["80: ESnet to GA-EAST"]
          },
          "group" : "group_27",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v6"
       },
       "ESnet_to_GA-EAST_IPv6_Throughput_Testing" : {
@@ -18707,6 +14766,7 @@
          },
          "group" : "group_26",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v6",
          "tools" : [
             "bwctliperf3",
@@ -18724,6 +14784,7 @@
             "display-task-group": ["50: ESnet to Europe"]
          },
          "group" : "group_19",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_to_GEANT_Throughput_Testing" : {
@@ -18738,6 +14799,7 @@
          },
          "group" : "group_18",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18755,6 +14817,7 @@
          },
          "group" : "group_18",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_to_ESGF_Site_Packet_Loss_Testing" : {
@@ -18768,6 +14831,7 @@
             "display-task-group": ["70: ESnet to ESGF Sites"]
          },
          "group" : "group_23",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_to_ESGF_Site_Throughput_Testing" : {
@@ -18782,6 +14846,7 @@
          },
          "group" : "group_22",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18799,6 +14864,7 @@
          },
          "group" : "group_22",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_to_International_Packet_Loss_Testing" : {
@@ -18812,6 +14878,7 @@
             "display-task-group": ["60: ESnet to International"]
          },
          "group" : "group_34",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_to_International_Throughput_Testing" : {
@@ -18826,6 +14893,7 @@
          },
          "group" : "group_33",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18843,6 +14911,7 @@
          },
          "group" : "group_33",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_to_KSTAR_Sites_Packet_Loss_Testing" : {
@@ -18855,6 +14924,7 @@
             "display-task-name": "{% jq .task._meta.\"display-name\" %}"
          },
          "group" : "group_21",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_to_KSTAR_Sites_Throughput_Testing" : {
@@ -18868,6 +14938,7 @@
          },
          "group" : "group_20",
          "schedule" : "schedule_2",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18885,6 +14956,7 @@
             "display-task-group": ["40: ESnet to Large Facilities"]
          },
          "group" : "group_11",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v6"
       },
       "ESnet_to_Large_Facility_IPv4_Packet_Loss_Testing" : {
@@ -18898,6 +14970,7 @@
             "display-task-group": ["40: ESnet to Large Facilities"]
          },
          "group" : "group_11",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_to_Large_Facility_IPv6_Throughput_Testing" : {
@@ -18912,6 +14985,7 @@
          },
          "group" : "group_10",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v6",
          "tools" : [
             "bwctliperf3",
@@ -18930,6 +15004,7 @@
          },
          "group" : "group_10",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18947,6 +15022,7 @@
          },
          "group" : "group_10",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_to_US_Regional_Networks_Packet_Loss" : {
@@ -18959,6 +15035,7 @@
             "display-task-name": "{% jq .task._meta.\"display-name\" %}"
          },
          "group" : "group_25",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_to_US_Regional_Networks_Throughput" : {
@@ -18972,6 +15049,7 @@
          },
          "group" : "group_24",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -18989,6 +15067,7 @@
             "display-task-group": ["91: ESnet to Universities"]
          },
          "group" : "group_13",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "ESnet_to_University_Throughput_Testing" : {
@@ -19003,6 +15082,7 @@
          },
          "group" : "group_12",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -19021,6 +15101,7 @@
          },
          "group" : "group_12",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "IU_Training_Packet_Loss_Testing" : {
@@ -19033,6 +15114,7 @@
             "display-task-name": "{% jq .task._meta.\"display-name\" %}"
          },
          "group" : "group_38",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "IU_Training_Throughput_Testing" : {
@@ -19046,6 +15128,7 @@
          },
          "group" : "group_37",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -19062,6 +15145,7 @@
             "display-task-name": "{% jq .task._meta.\"display-name\" %}"
          },
          "group" : "group_36",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
       },
       "KAUST_Testing_-_Throughput" : {
@@ -19075,6 +15159,7 @@
          },
          "group" : "group_35",
          "schedule" : "schedule_2",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4",
          "tools" : [
             "bwctliperf3",
@@ -19092,6 +15177,7 @@
          },
          "group" : "group_35",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_Backup_Paths_-_Throughput" : {
@@ -19106,6 +15192,7 @@
          },
          "group" : "group_39",
          "schedule" : "schedule_0",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4"
       },
       "ESnet_Backup_Paths_-_Loss" : {
@@ -19119,6 +15206,7 @@
             "display-task-group": ["90: ESnet Backup Paths"]
          },
          "group" : "group_40",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
      },
      "ESnet_EQX_Packet_Loss_Testing" : {
@@ -19131,6 +15219,7 @@
            "display-task-name": "{% jq .task._meta.\"display-name\" %}"
         },
         "group" : "group_eqx",
+        "archives": [ "ps-east" ],
         "test" : "ESnet6_LAT_1_v4"
      },
      "ESnet_NetLab_Packet_Loss_Testing" : {
@@ -19143,6 +15232,7 @@
            "display-task-name": "{% jq .task._meta.\"display-name\" %}"
         },
         "group" : "group_netlab",
+        "archives": [ "ps-east" ],
         "test" : "ESnet6_LAT_1_v4"
      },
      "DOENET_ORO_Packet_Loss_Testing" : {
@@ -19155,6 +15245,7 @@
            "display-task-name": "{% jq .task._meta.\"display-name\" %}"
         },
         "group" : "group_doenetoro_owamp",
+        "archives": [ "ps-east" ],
         "test" : "ESnet6_LAT_1_v4"
     },
     "DOENET_ORO_Throughput_Testing" : {
@@ -19167,6 +15258,7 @@
           "display-task-name": "{% jq .task._meta.\"display-name\" %}"
        },
        "group" : "group_doenetoro_pt1",
+       "archives": [ "ps-east" ],
        "test" : "ESnet6_TP_1_v4",
        "schedule": "schedule_0"
     },
@@ -19180,6 +15272,7 @@
           "display-task-name": "{% jq .task._meta.\"display-name\" %}"
        },
        "group" : "group_simons_observ_owamp",
+       "archives": [ "ps-east" ],
        "test" : "ESnet6_LAT_1_v4"
      },
      "ESnet_to_Simons_Observatory_Throughput_Testing" : {
@@ -19193,6 +15286,7 @@
         },
         "group" : "group_simons_observ_pt",
         "schedule" : "schedule_0",
+        "archives": [ "ps-east" ],
         "test" : "ESnet6_TP_1_v4"
       },
       "ESnet_to_Simons_Observatory_Traceroute_Testing" : {
@@ -19206,6 +15300,7 @@
          },
          "group" : "group_simons_observ_pt",
          "schedule" : "schedule_1",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_v4_trace"
       },
       "ESnet_to_NREL_Throughput_Testing" : {
@@ -19218,6 +15313,7 @@
             "display-task-name": "{% jq .task._meta.\"display-name\" %}"
          },
          "group" : "group_nrel_thrupt",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_TP_1_v4"
        },
       "ESnet_to_NREL_Loss_Testing" : {
@@ -19230,6 +15326,7 @@
             "display-task-name": "{% jq .task._meta.\"display-name\" %}"
          },
          "group" : "group_nrel_owamp",
+         "archives": [ "ps-east" ],
          "test" : "ESnet6_LAT_1_v4"
        },
         "ESnet_to_NREL_Traceroute_Testing" : {
@@ -19243,6 +15340,7 @@
            },
            "group" : "group_nrel_owamp",
            "schedule" : "schedule_1",
+           "archives": [ "ps-east" ],
            "test" : "ESnet6_v4_trace"
         },
         "JLAB_GlueX_Throughput_Testing" : {
@@ -19255,6 +15353,7 @@
               "display-task-name": "{% jq .task._meta.\"display-name\" %}"
            },
            "group" : "group_gluex_thrupt",
+           "archives": [ "ps-east" ],
            "test" : "ESnet6_TP_1_v4"
          },
         "JLAB_GlueX_Loss_Testing" : {
@@ -19267,6 +15366,7 @@
               "display-task-name": "{% jq .task._meta.\"display-name\" %}"
            },
            "group" : "group_gluex_owamp",
+           "archives": [ "ps-east" ],
            "test" : "ESnet6_LAT_1_v4"
          },
           "JLAB_GlueX_Traceroute_Testing" : {
@@ -19280,6 +15380,7 @@
              },
              "group" : "group_gluex_thrupt",
              "schedule" : "schedule_1",
+             "archives": [ "ps-east" ],
              "test" : "ESnet6_v4_trace"
           },
           "FRIB_Throughput_Testing" : {
@@ -19293,6 +15394,7 @@
                "display-task-group": ["71: ESnet to FRIB"]
             },
             "group" : "group_frib",
+            "archives": [ "ps-east" ],
             "test" : "ESnet6_TP_1_v4"
           },
          "FRIB_Loss_Testing" : {
@@ -19306,6 +15408,7 @@
                "display-task-group": ["71: ESnet to FRIB"]
             },
             "group" : "group_frib",
+            "archives": [ "ps-east" ],
             "test" : "ESnet6_LAT_1_v4"
           },
            "FRIB_Traceroute_Testing" : {
@@ -19320,6 +15423,7 @@
               },
               "group" : "group_frib",
               "schedule" : "schedule_1",
+              "archives": [ "ps-east" ],
               "test" : "ESnet6_v4_trace"
            },
            "LHCONE_IPv4_Throughput_Testing" : {
@@ -19333,6 +15437,7 @@
                "display-task-group": ["51: ESnet-LHCONE"]
             },
             "group" : "group_lhcone_throughput",
+            "archives": [ "ps-east" ],
             "test" : "ESnet6_TP_1_v4"
           },
          "LHCONE_IPv4_Loss_Testing" : {
@@ -19346,6 +15451,7 @@
                "display-task-group": ["51: ESnet-LHCONE"]
             },
             "group" : "group_lhcone_latency",
+            "archives": [ "ps-east" ],
             "test" : "ESnet6_LAT_1_v4"
           },
            "LHCONE_IPv4_Traceroute_Testing" : {
@@ -19360,6 +15466,7 @@
               },
               "group" : "group_lhcone_throughput",
               "schedule" : "schedule_1",
+              "archives": [ "ps-east" ],
               "test" : "ESnet6_v4_trace"
            },
            "LHCONE_IPv6_Throughput_Testing" : {
@@ -19373,6 +15480,7 @@
                "display-task-group": ["51: ESnet-LHCONE"]
             },
             "group" : "group_lhcone_throughput",
+            "archives": [ "ps-east" ],
             "test" : "ESnet6_TP_1_v6"
           },
          "LHCONE_IPv6_Loss_Testing" : {
@@ -19386,6 +15494,7 @@
                "display-task-group": ["51: ESnet-LHCONE"]
             },
             "group" : "group_lhcone_latency",
+            "archives": [ "ps-east" ],
             "test" : "ESnet6_LAT_1_v6"
           },
            "LHCONE_IPv6_Traceroute_Testing" : {
@@ -19400,6 +15509,7 @@
               },
               "group" : "group_lhcone_throughput",
               "schedule" : "schedule_1",
+              "archives": [ "ps-east" ],
               "test" : "ESnet6_v6_trace"
            },
            "LHCONE_US_IPv6_Loss_Testing" : {
@@ -19413,6 +15523,7 @@
                "display-task-group": ["51: ESnet-LHCONE"]
             },
             "group" : "group_lhcone_us_latency",
+            "archives": [ "ps-east" ],
             "test" : "ESnet6_LAT_1_v6"
           },
            "NSF_SuperComputers_IPv4_Throughput_Testing" : {
@@ -19426,6 +15537,7 @@
                "display-task-group": ["41: ESnet to NSF-Supported SuperComputers"]
             },
             "group" : "group_NSF_SC_throughput",
+            "archives": [ "ps-east" ],
             "test" : "ESnet6_TP_1_v4"
           },
          "NSF_SuperComputers_IPv4_Loss_Testing" : {
@@ -19439,6 +15551,7 @@
                "display-task-group": ["41: ESnet to NSF-Supported SuperComputers"]
             },
             "group" : "group_NSF_SC_latency",
+            "archives": [ "ps-east" ],
             "test" : "ESnet6_LAT_1_v4"
           },
            "NSF_SuperComputers_IPv4_Traceroute_Testing" : {
@@ -19453,6 +15566,7 @@
               },
               "group" : "group_NSF_SC_throughput",
               "schedule" : "schedule_1",
+              "archives": [ "ps-east" ],
               "test" : "ESnet6_v4_trace"
            }         
    },


### PR DESCRIPTION
There are a bunch of individual archiver definitions we don't need. We really just need the ps-east one so maddash knows where to get results. The ESnet hosts themselves define the archiver locally and have configure_archives set to false, so the definitions that were there were really just a bunch of clutter.

Going forward, any new tasks should have `"archives": [ "ps-east" ]` and we should be set. No need to define a new archive or define anything for individual hosts.